### PR TITLE
Revert the kernel back to 6.6.34

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,5 @@
 pkg=linux
-version_orig=6.6.35
+version_orig=6.6.34
 version="$version_orig-0"
 
 (


### PR DESCRIPTION
When using UEFI and booting the 6.6.35 kernel the VM will not boot up with the following error message(qemu):

    BdsDxe: loading Boot0001 "UEFI Misc Device" from PciRoot(0x0)/Pci(0x2,0x0)
    ConvertPages: failed to find range 1C22E0000 - 1C22FBFFF
    BdsDxe: starting Boot0001 "UEFI Misc Device" from PciRoot(0x0)/Pci(0x2,0x0)
    EFI stub: Booting Linux Kernel...
    EFI stub: EFI_RNG_PROTOCOL unavailable
    EFI stub: Loaded initrd from LINUX_EFI_INITRD_MEDIA_GUID device path
    EFI stub: Generating empty DTB
    EFI stub: Exiting boot services...

And on AWS:

    UEFI firmware (version  built at 09:00:00 on Nov  1 2018)

    [2J[01;01H[=3h[2J[01;01H[2J[01;01H[=3h[2J[01;01H[2J[01;01H[=3h[2J[01;01H[0m[35m[40m[0m[37m[40mEFI
    stub: Booting Linux Kernel...

    EFI stub: Loaded initrd from LINUX_EFI_INITRD_MEDIA_GUID device path

    EFI stub: Generating empty DTB

    EFI stub: Exiting boot services.

IT seems that the patches for kernel 6.6.35 might have cherry-picked some changes that arn't represented for the arm64 branch.  This might leads to the sitation where the kernel does not boot or it's alignmned is incorrect. In short we can't boot.

And while we have no certainy about the why we can see that the problem isn't presented on 6.6.34.

Resolves: #gardenlinux-2170

[0]: https://lkml.iu.edu/hypermail/linux/kernel/2406.1/05279.html


