### PR TITLE
Add helper script to automate updating the kernel to the latest version

### DIFF
--- a/.github/workflows/pr-if-new-kernel.yml
+++ b/.github/workflows/pr-if-new-kernel.yml
@@ -24,7 +24,7 @@ jobs:
             git config --global user.name "Garden Linux Builder"
             git config --global user.email "gardenlinux@users.noreply.github.com"
             git commit -m 'Update kernel ${{ steps.update.outputs.has-update }}'
-            gh pr create -B main -H update-kernel --title 'Update kernel ${{ steps.update.outputs.has-update }}'
+            gh pr create --base main --head update-kernel --title 'Update kernel ${{ steps.update.outputs.has-update }}' --reviewer gardenlinux/garden-linux-maintainers
           fi
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-if-new-kernel.yml
+++ b/.github/workflows/pr-if-new-kernel.yml
@@ -1,0 +1,30 @@
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: |
+          OUTPUT=${python update-kernel.py}
+          echo $OUTPUT
+          echo "has-update=$OUTPUT" >> "$GITHUB_OUTPUT"
+        id: update
+      - name: create pull request
+        run: |
+          if [[ '${{ steps.update.outputs.has-update }}' ]]; then
+            git branch update-kernel
+            git add prepare_source
+            git config --global user.name "Garden Linux Builder"
+            git config --global user.email "gardenlinux@users.noreply.github.com"
+            git commit -m 'Update kernel ${{ steps.update.outputs.has-update }}'
+            gh pr create -B main -H update-kernel --title 'Update kernel ${{ steps.update.outputs.has-update }}'
+          fi
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-if-new-kernel.yml
+++ b/.github/workflows/pr-if-new-kernel.yml
@@ -5,26 +5,29 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
-
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - run: |
-          OUTPUT=${python update-kernel.py}
+          OUTPUT=$(python update-kernel.py)
           echo $OUTPUT
           echo "has-update=$OUTPUT" >> "$GITHUB_OUTPUT"
         id: update
       - name: create pull request
         run: |
           if [[ '${{ steps.update.outputs.has-update }}' ]]; then
-            git branch update-kernel
+            git checkout -b update-kernel
             git add prepare_source
             git config --global user.name "Garden Linux Builder"
             git config --global user.email "gardenlinux@users.noreply.github.com"
-            git commit -m 'Update kernel ${{ steps.update.outputs.has-update }}'
-            gh pr create --base main --head update-kernel --title 'Update kernel ${{ steps.update.outputs.has-update }}' --reviewer gardenlinux/garden-linux-maintainers
+            git commit -am 'Update kernel ${{ steps.update.outputs.has-update }}'
+            git push --set-upstream origin update-kernel
+            gh pr create --base main --head update-kernel --title 'Update kernel ${{ steps.update.outputs.has-update }}' --body "automated update" --reviewer gardenlinux/garden-linux-maintainers
           fi
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/update-kernel.py
+++ b/update-kernel.py
@@ -1,0 +1,30 @@
+from urllib.request import urlopen
+import json
+import re
+
+current_lts = '6.6'
+script_content = ""
+
+def update_version(file_path, new_version):
+    # Define the regex pattern to match the version_orig variable
+    pattern = re.compile(r'(version_orig=)([\d\.]+)')
+    
+    with open(file_path, 'r') as file:
+        script_content = file.read()
+    
+    # Search for the pattern and replace the version_orig value
+    updated_content = pattern.sub(r'\1{}'.format(re.escape(new_version)), script_content)
+    
+    with open(file_path, 'w') as file:
+        file.write(updated_content)
+
+with urlopen("https://www.kernel.org/releases.json") as response:
+    releases = json.loads(response.read().decode())["releases"]
+    latest_current_lts = [
+        r['version'] for r in releases if r["moniker"] == "longterm" and r["iseol"] == False and r['version'].startswith(current_lts)
+    ]
+    assert len(latest_current_lts) == 1
+    print(latest_current_lts[0])
+    new_version=latest_current_lts[0]
+
+    update_version('prepare_source', new_version)

--- a/update-kernel.py
+++ b/update-kernel.py
@@ -1,5 +1,6 @@
 from urllib.request import urlopen
 import json
+import sys
 
 # Script to automate the process of selecting the latest patch version of linux
 
@@ -18,7 +19,6 @@ def get_latest_kernel_version():
             and r["version"].startswith(current_lts)
         ]
         assert len(latest_current_lts) == 1
-        print(latest_current_lts[0])
         new_version = latest_current_lts[0]
         return new_version
 
@@ -34,6 +34,10 @@ def update_version_in_script(file_path, new_version):
         old_version = version_orig_line[0].split("=")[1]
         assert old_version.startswith(current_lts)
 
+        if old_version == new_version:
+            sys.exit(0)
+
+        print(f"{old_version} -> {new_version}")
         updated_content = script_content.replace(old_version, new_version, 1)
 
     with open(file_path, "w") as file:


### PR DESCRIPTION
This script can reduce the effort of keeping our kernel updated a little bit by automatically replacing the version with the latest one.
Run on schedule to create prs for new kernel versions automatically.
