### PR TITLE
Add comment to workflow url in PR if a new kernel is available

### DIFF
--- a/.github/workflows/pr-if-new-kernel.yml
+++ b/.github/workflows/pr-if-new-kernel.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 5 * * *'
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -28,8 +28,12 @@ jobs:
             git config --global user.email "gardenlinux@users.noreply.github.com"
             git commit -am 'Update kernel ${{ steps.update.outputs.has-update }}'
             git push --set-upstream origin update-kernel
-            gh pr create --base main --head update-kernel --title 'Update kernel ${{ steps.update.outputs.has-update }}' --body "automated update" --reviewer fwilhe
+            UPDATE_PR_LINK=$(gh pr create --base main --head update-kernel --title 'Update kernel ${{ steps.update.outputs.has-update }}' --body "automated update" --reviewer fwilhe)
+            # We have to trigger our own workflow run because github does not do that when the pr is created by automation
+            # This also means that we don't have the nice UI integration of test runs, so we add a comment to the workflow url for tracing purposes
             gh workflow run "build.yml" --ref "update-kernel"
+            RUN_URL=$(gh run list --workflow=build.yml --limit=1 --json=url --jq='.[0].url')
+            gh pr comment $UPDATE_PR_LINK --body "CI workflow created: $RUN_URL"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Improve our automation for creating PRs when new kernel versions are released.
We have to trigger our own workflow run because github does not do that when the pr is created by automation
This also means that we don't have the nice UI integration of test runs, so we add a comment to the workflow url for tracing purposes
