### PR TITLE
Update debian's kernel build to 6.12.9-1

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -5,7 +5,7 @@ version="$version_orig-1"
 (
 	kernel_repo=https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
 	debian_repo=https://salsa.debian.org/kernel-team/linux.git
-	debian_ref="debian/6.12.8-1"
+	debian_ref="debian/6.12.9-1"
 
 	tmp_dir="$(mktemp -d)"
 	trap 'cd / && rm -rf "$tmp_dir"' EXIT


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the tag from debian's kernel repo to match the kernel version we have.
