### PR TITLE
debian patch refresh for 6.6.76

### DIFF
--- a/fixes_debian/refresh-debian_firmware-remove-redundant-log-messages-from-drivers.patch
+++ b/fixes_debian/refresh-debian_firmware-remove-redundant-log-messages-from-drivers.patch
@@ -1,0 +1,1569 @@
+diff -Naur a/debian/patches/bugfix/all/firmware-remove-redundant-log-messages-from-drivers.patch b/debian/patches/bugfix/all/firmware-remove-redundant-log-messages-from-drivers.patch
+--- a/debian/patches/bugfix/all/firmware-remove-redundant-log-messages-from-drivers.patch	2025-02-12 12:22:41.921590276 +0000
++++ b/debian/patches/bugfix/all/firmware-remove-redundant-log-messages-from-drivers.patch	2025-02-12 13:06:56.978102802 +0000
+@@ -11,7 +11,7 @@
+ 
+ --- a/arch/x86/kernel/cpu/microcode/amd.c
+ +++ b/arch/x86/kernel/cpu/microcode/amd.c
+-@@ -912,10 +912,8 @@ static enum ucode_state request_microcod
++@@ -912,10 +912,8 @@
+  	if (c->x86 >= 0x15)
+  		snprintf(fw_name, sizeof(fw_name), "amd-ucode/microcode_amd_fam%.2xh.bin", c->x86);
+  
+@@ -25,7 +25,7 @@
+  	if (!verify_container(fw->data, fw->size, false))
+ --- a/drivers/atm/fore200e.c
+ +++ b/drivers/atm/fore200e.c
+-@@ -2398,10 +2398,9 @@ static int fore200e_load_and_start_fw(st
++@@ -2398,10 +2398,9 @@
+      int err;
+  
+      sprintf(buf, "%s%s", fore200e->bus->proc_name, FW_EXT);
+@@ -40,7 +40,7 @@
+      fw_size = firmware->size / sizeof(u32);
+ --- a/drivers/bluetooth/ath3k.c
+ +++ b/drivers/bluetooth/ath3k.c
+-@@ -381,10 +381,8 @@ static int ath3k_load_patch(struct usb_d
++@@ -379,10 +379,8 @@
+  		 le32_to_cpu(fw_version.rom_version));
+  
+  	ret = request_firmware(&firmware, filename, &udev->dev);
+@@ -52,7 +52,7 @@
+  
+  	pt_rom_version = get_unaligned_le32(firmware->data +
+  					    firmware->size - 8);
+-@@ -441,10 +441,8 @@
++@@ -441,10 +439,8 @@
+  		 le32_to_cpu(fw_version.rom_version), clk_value, ".dfu");
+  
+  	ret = request_firmware(&firmware, filename, &udev->dev);
+@@ -66,7 +66,7 @@
+  	release_firmware(firmware);
+ --- a/drivers/bluetooth/bcm203x.c
+ +++ b/drivers/bluetooth/bcm203x.c
+-@@ -173,7 +173,6 @@ static int bcm203x_probe(struct usb_inte
++@@ -173,7 +173,6 @@
+  		return -ENOMEM;
+  
+  	if (request_firmware(&firmware, "BCM2033-MD.hex", &udev->dev) < 0) {
+@@ -74,7 +74,7 @@
+  		usb_free_urb(data->urb);
+  		return -EIO;
+  	}
+-@@ -198,7 +197,6 @@ static int bcm203x_probe(struct usb_inte
++@@ -198,7 +197,6 @@
+  	release_firmware(firmware);
+  
+  	if (request_firmware(&firmware, "BCM2033-FW.bin", &udev->dev) < 0) {
+@@ -84,7 +84,7 @@
+  		return -EIO;
+ --- a/drivers/bluetooth/bfusb.c
+ +++ b/drivers/bluetooth/bfusb.c
+-@@ -639,10 +639,8 @@ static int bfusb_probe(struct usb_interf
++@@ -639,10 +639,8 @@
+  	skb_queue_head_init(&data->pending_q);
+  	skb_queue_head_init(&data->completed_q);
+  
+@@ -98,7 +98,7 @@
+  
+ --- a/drivers/bluetooth/bt3c_cs.c
+ +++ b/drivers/bluetooth/bt3c_cs.c
+-@@ -569,10 +569,8 @@ static int bt3c_open(struct bt3c_info *i
++@@ -569,10 +569,8 @@
+  
+  	/* Load firmware */
+  	err = request_firmware(&firmware, "BT3CPCC.bin", &info->p_dev->dev);
+@@ -112,7 +112,7 @@
+  
+ --- a/drivers/bluetooth/btmrvl_sdio.c
+ +++ b/drivers/bluetooth/btmrvl_sdio.c
+-@@ -470,8 +470,6 @@ static int btmrvl_sdio_download_helper(s
++@@ -469,8 +469,6 @@
+  	ret = request_firmware(&fw_helper, card->helper,
+  						&card->func->dev);
+  	if ((ret < 0) || !fw_helper) {
+@@ -121,7 +121,7 @@
+  		ret = -ENOENT;
+  		goto done;
+  	}
+-@@ -570,8 +568,6 @@ static int btmrvl_sdio_download_fw_w_hel
++@@ -569,8 +567,6 @@
+  	ret = request_firmware(&fw_firmware, card->firmware,
+  							&card->func->dev);
+  	if ((ret < 0) || !fw_firmware) {
+@@ -132,7 +132,7 @@
+  	}
+ --- a/drivers/char/dsp56k.c
+ +++ b/drivers/char/dsp56k.c
+-@@ -142,11 +142,8 @@ static int dsp56k_upload(u_char __user *
++@@ -142,11 +142,8 @@
+  	}
+  	err = request_firmware(&fw, fw_name, &pdev->dev);
+  	platform_device_unregister(pdev);
+@@ -147,7 +147,7 @@
+  		       fw->size, fw_name);
+ --- a/drivers/dma/imx-sdma.c
+ +++ b/drivers/dma/imx-sdma.c
+-@@ -1933,11 +1933,8 @@ static void sdma_load_firmware(const str
++@@ -1933,11 +1933,8 @@
+  	const struct sdma_script_start_addrs *addr;
+  	unsigned short *ram_code;
+  
+@@ -162,7 +162,7 @@
+  		goto err_firmware;
+ --- a/drivers/gpu/drm/nouveau/nvkm/engine/gr/gf100.c
+ +++ b/drivers/gpu/drm/nouveau/nvkm/engine/gr/gf100.c
+-@@ -2579,10 +2579,8 @@ gf100_gr_load_fw(struct gf100_gr *gr, co
++@@ -2580,10 +2580,8 @@
+  	if (ret) {
+  		snprintf(f, sizeof(f), "nouveau/%s", name);
+  		ret = request_firmware(&fw, f, device->dev);
+@@ -176,7 +176,7 @@
+  	blob->size = fw->size;
+ --- a/drivers/gpu/drm/radeon/ni.c
+ +++ b/drivers/gpu/drm/radeon/ni.c
+-@@ -820,9 +820,6 @@ int ni_init_microcode(struct radeon_devi
++@@ -820,9 +820,6 @@
+  
+  out:
+  	if (err) {
+@@ -188,7 +188,7 @@
+  		release_firmware(rdev->me_fw);
+ --- a/drivers/gpu/drm/radeon/r100.c
+ +++ b/drivers/gpu/drm/radeon/r100.c
+-@@ -1057,9 +1057,7 @@ static int r100_cp_init_microcode(struct
++@@ -1077,9 +1077,7 @@
+  	}
+  
+  	err = request_firmware(&rdev->me_fw, fw_name, rdev->dev);
+@@ -201,7 +201,7 @@
+  		err = -EINVAL;
+ --- a/drivers/gpu/drm/radeon/r600.c
+ +++ b/drivers/gpu/drm/radeon/r600.c
+-@@ -2600,9 +2600,6 @@ int r600_init_microcode(struct radeon_de
++@@ -2600,9 +2600,6 @@
+  
+  out:
+  	if (err) {
+@@ -213,7 +213,7 @@
+  		release_firmware(rdev->me_fw);
+ --- a/drivers/infiniband/hw/qib/qib_sd7220.c
+ +++ b/drivers/infiniband/hw/qib/qib_sd7220.c
+-@@ -406,10 +406,8 @@ int qib_sd7220_init(struct qib_devdata *
++@@ -406,10 +406,8 @@
+  	}
+  
+  	ret = request_firmware(&fw, SD7220_FW_NAME, &dd->pcidev->dev);
+@@ -227,7 +227,7 @@
+  	ret = qib_ibsd_ucode_loaded(dd->pport, fw);
+ --- a/drivers/input/touchscreen/atmel_mxt_ts.c
+ +++ b/drivers/input/touchscreen/atmel_mxt_ts.c
+-@@ -2927,10 +2927,8 @@ static int mxt_load_fw(struct device *de
++@@ -2927,10 +2927,8 @@
+  	int ret;
+  
+  	ret = request_firmware(&fw, fn, dev);
+@@ -241,7 +241,7 @@
+  	ret = mxt_check_firmware_format(dev, fw);
+ --- a/drivers/isdn/hardware/mISDN/speedfax.c
+ +++ b/drivers/isdn/hardware/mISDN/speedfax.c
+-@@ -379,11 +379,8 @@ setup_instance(struct sfax_hw *card)
++@@ -379,11 +379,8 @@
+  	card->isar.owner = THIS_MODULE;
+  
+  	err = request_firmware(&firmware, "isdn/ISAR.BIN", &card->pdev->dev);
+@@ -256,7 +256,7 @@
+  			  card->name, firmware->size);
+ --- a/drivers/media/common/siano/smscoreapi.c
+ +++ b/drivers/media/common/siano/smscoreapi.c
+-@@ -1152,10 +1152,8 @@ static int smscore_load_firmware_from_fi
++@@ -1152,10 +1152,8 @@
+  		return -EINVAL;
+  
+  	rc = request_firmware(&fw, fw_filename, coredev->device);
+@@ -270,7 +270,7 @@
+  			 SMS_ALLOC_ALIGNMENT), GFP_KERNEL | coredev->gfp_buf_flags);
+ --- a/drivers/media/dvb-frontends/af9013.c
+ +++ b/drivers/media/dvb-frontends/af9013.c
+-@@ -1049,14 +1049,8 @@ static int af9013_download_firmware(stru
++@@ -1049,14 +1049,8 @@
+  
+  	/* Request the firmware, will block and timeout */
+  	ret = request_firmware(&firmware, name, &client->dev);
+@@ -288,7 +288,7 @@
+  	for (i = 0; i < firmware->size; i++)
+ --- a/drivers/media/dvb-frontends/bcm3510.c
+ +++ b/drivers/media/dvb-frontends/bcm3510.c
+-@@ -636,10 +636,9 @@ static int bcm3510_download_firmware(str
++@@ -636,10 +636,9 @@
+  	int ret,i;
+  
+  	deb_info("requesting firmware\n");
+@@ -303,7 +303,7 @@
+  	b = fw->data;
+ --- a/drivers/media/dvb-frontends/cx24116.c
+ +++ b/drivers/media/dvb-frontends/cx24116.c
+-@@ -479,13 +479,8 @@ static int cx24116_firmware_ondemand(str
++@@ -479,13 +479,8 @@
+  			__func__, CX24116_DEFAULT_FIRMWARE);
+  		ret = request_firmware(&fw, CX24116_DEFAULT_FIRMWARE,
+  			state->i2c->dev.parent);
+@@ -320,7 +320,7 @@
+  		 * during loading */
+ --- a/drivers/media/dvb-frontends/drxd_hard.c
+ +++ b/drivers/media/dvb-frontends/drxd_hard.c
+-@@ -891,10 +891,8 @@ static int load_firmware(struct drxd_sta
++@@ -891,10 +891,8 @@
+  {
+  	const struct firmware *fw;
+  
+@@ -334,7 +334,7 @@
+  	if (!state->microcode) {
+ --- a/drivers/media/dvb-frontends/drxk_hard.c
+ +++ b/drivers/media/dvb-frontends/drxk_hard.c
+-@@ -6228,10 +6228,6 @@ static void load_firmware_cb(const struc
++@@ -6228,10 +6228,6 @@
+  
+  	dprintk(1, ": %s\n", fw ? "firmware loaded" : "firmware not loaded");
+  	if (!fw) {
+@@ -347,7 +347,7 @@
+  		/*
+ --- a/drivers/media/dvb-frontends/ds3000.c
+ +++ b/drivers/media/dvb-frontends/ds3000.c
+-@@ -348,12 +348,8 @@ static int ds3000_firmware_ondemand(stru
++@@ -348,12 +348,8 @@
+  				DS3000_DEFAULT_FIRMWARE);
+  	ret = request_firmware(&fw, DS3000_DEFAULT_FIRMWARE,
+  				state->i2c->dev.parent);
+@@ -363,7 +363,7 @@
+  	if (ret)
+ --- a/drivers/media/dvb-frontends/nxt200x.c
+ +++ b/drivers/media/dvb-frontends/nxt200x.c
+-@@ -861,12 +861,8 @@ static int nxt2002_init(struct dvb_front
++@@ -861,12 +861,8 @@
+  		 __func__, NXT2002_DEFAULT_FIRMWARE);
+  	ret = request_firmware(&fw, NXT2002_DEFAULT_FIRMWARE,
+  			       state->i2c->dev.parent);
+@@ -377,7 +377,7 @@
+  
+  	ret = nxt2002_load_firmware(fe, fw);
+  	release_firmware(fw);
+-@@ -928,12 +924,8 @@ static int nxt2004_init(struct dvb_front
++@@ -928,12 +924,8 @@
+  		 __func__, NXT2004_DEFAULT_FIRMWARE);
+  	ret = request_firmware(&fw, NXT2004_DEFAULT_FIRMWARE,
+  			       state->i2c->dev.parent);
+@@ -393,7 +393,7 @@
+  	release_firmware(fw);
+ --- a/drivers/media/dvb-frontends/or51132.c
+ +++ b/drivers/media/dvb-frontends/or51132.c
+-@@ -326,10 +326,8 @@ static int or51132_set_parameters(struct
++@@ -326,10 +326,8 @@
+  		printk("or51132: Waiting for firmware upload(%s)...\n",
+  		       fwname);
+  		ret = request_firmware(&fw, fwname, state->i2c->dev.parent);
+@@ -407,7 +407,7 @@
+  		if (ret) {
+ --- a/drivers/media/dvb-frontends/or51211.c
+ +++ b/drivers/media/dvb-frontends/or51211.c
+-@@ -361,11 +361,8 @@ static int or51211_init(struct dvb_front
++@@ -361,11 +361,8 @@
+  			OR51211_DEFAULT_FIRMWARE);
+  		ret = config->request_firmware(fe, &fw,
+  					       OR51211_DEFAULT_FIRMWARE);
+@@ -422,7 +422,7 @@
+  		release_firmware(fw);
+ --- a/drivers/media/dvb-frontends/sp887x.c
+ +++ b/drivers/media/dvb-frontends/sp887x.c
+-@@ -525,10 +525,8 @@ static int sp887x_init(struct dvb_fronte
++@@ -525,10 +525,8 @@
+  		/* request the firmware, this will block until someone uploads it */
+  		printk("sp887x: waiting for firmware upload (%s)...\n", SP887X_DEFAULT_FIRMWARE);
+  		ret = state->config->request_firmware(fe, &fw, SP887X_DEFAULT_FIRMWARE);
+@@ -436,7 +436,7 @@
+  		release_firmware(fw);
+ --- a/drivers/media/dvb-frontends/tda10048.c
+ +++ b/drivers/media/dvb-frontends/tda10048.c
+-@@ -483,8 +483,6 @@ static int tda10048_firmware_upload(stru
++@@ -486,8 +486,6 @@
+  	ret = request_firmware(&fw, TDA10048_DEFAULT_FIRMWARE,
+  		state->i2c->dev.parent);
+  	if (ret) {
+@@ -447,7 +447,7 @@
+  		printk(KERN_INFO "%s: firmware read %zu bytes.\n",
+ --- a/drivers/media/dvb-frontends/tda1004x.c
+ +++ b/drivers/media/dvb-frontends/tda1004x.c
+-@@ -388,10 +388,8 @@ static int tda10045_fwupload(struct dvb_
++@@ -388,10 +388,8 @@
+  	/* request the firmware, this will block until someone uploads it */
+  	printk(KERN_INFO "tda1004x: waiting for firmware upload (%s)...\n", TDA10045_DEFAULT_FIRMWARE);
+  	ret = state->config->request_firmware(fe, &fw, TDA10045_DEFAULT_FIRMWARE);
+@@ -459,7 +459,7 @@
+  
+  	/* reset chip */
+  	tda1004x_write_mask(state, TDA1004X_CONFC4, 0x10, 0);
+-@@ -532,7 +530,6 @@ static int tda10046_fwupload(struct dvb_
++@@ -532,7 +530,6 @@
+  			/* remain compatible to old bug: try to load with tda10045 image name */
+  			ret = state->config->request_firmware(fe, &fw, TDA10045_DEFAULT_FIRMWARE);
+  			if (ret) {
+@@ -469,7 +469,7 @@
+  				printk(KERN_INFO "tda1004x: please rename the firmware file to %s\n",
+ --- a/drivers/media/dvb-frontends/tda10071.c
+ +++ b/drivers/media/dvb-frontends/tda10071.c
+-@@ -838,12 +838,8 @@ static int tda10071_init(struct dvb_fron
++@@ -838,12 +838,8 @@
+  
+  		/* request the firmware, this will block and timeout */
+  		ret = request_firmware(&fw, fw_file, &client->dev);
+@@ -485,7 +485,7 @@
+  		for (i = 0; i < ARRAY_SIZE(tab2); i++) {
+ --- a/drivers/media/i2c/cx25840/cx25840-firmware.c
+ +++ b/drivers/media/i2c/cx25840/cx25840-firmware.c
+-@@ -113,10 +113,8 @@ int cx25840_loadfw(struct i2c_client *cl
++@@ -113,10 +113,8 @@
+  	if (is_cx231xx(state) && max_buf_size > 16)
+  		max_buf_size = 16;
+  
+@@ -499,7 +499,7 @@
+  
+ --- a/drivers/media/pci/bt8xx/bttv-cards.c
+ +++ b/drivers/media/pci/bt8xx/bttv-cards.c
+-@@ -3901,10 +3901,8 @@ static int pvr_boot(struct bttv *btv)
++@@ -3901,10 +3901,8 @@
+  	int rc;
+  
+  	rc = request_firmware(&fw_entry, "hcwamc.rbf", &btv->c.pci->dev);
+@@ -513,7 +513,7 @@
+  		btv->c.nr, (rc < 0) ? "failed" : "ok");
+ --- a/drivers/media/pci/cx18/cx18-av-firmware.c
+ +++ b/drivers/media/pci/cx18/cx18-av-firmware.c
+-@@ -70,10 +70,8 @@ int cx18_av_loadfw(struct cx18 *cx)
++@@ -70,10 +70,8 @@
+  	int i;
+  	int retries1 = 0;
+  
+@@ -527,7 +527,7 @@
+  	   retries, both at byte level and at the firmware load level. */
+ --- a/drivers/media/pci/cx18/cx18-dvb.c
+ +++ b/drivers/media/pci/cx18/cx18-dvb.c
+-@@ -127,9 +127,7 @@ static int yuan_mpc718_mt352_reqfw(struc
++@@ -127,9 +127,7 @@
+  	int ret;
+  
+  	ret = request_firmware(fw, fn, &cx->pci_dev->dev);
+@@ -540,7 +540,7 @@
+  			CX18_ERR("Firmware %s has a bad size: %lu bytes\n",
+ --- a/drivers/media/pci/cx18/cx18-firmware.c
+ +++ b/drivers/media/pci/cx18/cx18-firmware.c
+-@@ -92,11 +92,8 @@ static int load_cpu_fw_direct(const char
++@@ -92,11 +92,8 @@
+  	u32 __iomem *dst = (u32 __iomem *)mem;
+  	const u32 *src;
+  
+@@ -553,7 +553,7 @@
+  
+  	src = (const u32 *)fw->data;
+  
+-@@ -137,8 +134,6 @@ static int load_apu_fw_direct(const char
++@@ -137,8 +134,6 @@
+  	int sz;
+  
+  	if (request_firmware(&fw, fn, &cx->pci_dev->dev)) {
+@@ -564,7 +564,7 @@
+  	}
+ --- a/drivers/media/pci/cx23885/cx23885-417.c
+ +++ b/drivers/media/pci/cx23885/cx23885-417.c
+-@@ -920,12 +920,8 @@ static int cx23885_load_firmware(struct
++@@ -920,12 +920,8 @@
+  	retval = request_firmware(&firmware, CX23885_FIRM_IMAGE_NAME,
+  				  &dev->pci->dev);
+  
+@@ -580,7 +580,7 @@
+  		pr_err("ERROR: Firmware size mismatch (have %zu, expected %d)\n",
+ --- a/drivers/media/pci/cx23885/cx23885-cards.c
+ +++ b/drivers/media/pci/cx23885/cx23885-cards.c
+-@@ -2480,10 +2480,7 @@ void cx23885_card_setup(struct cx23885_d
++@@ -2480,10 +2480,7 @@
+  			cinfo.rev, filename);
+  
+  		ret = request_firmware(&fw, filename, &dev->pci->dev);
+@@ -594,7 +594,7 @@
+  		release_firmware(fw);
+ --- a/drivers/media/pci/cx88/cx88-blackbird.c
+ +++ b/drivers/media/pci/cx88/cx88-blackbird.c
+-@@ -462,12 +462,8 @@ static int blackbird_load_firmware(struc
++@@ -462,12 +462,8 @@
+  	retval = request_firmware(&firmware, CX2341X_FIRM_ENC_FILENAME,
+  				  &dev->pci->dev);
+  
+@@ -610,7 +610,7 @@
+  		pr_err("Firmware size mismatch (have %zd, expected %d)\n",
+ --- a/drivers/media/pci/ivtv/ivtv-firmware.c
+ +++ b/drivers/media/pci/ivtv/ivtv-firmware.c
+-@@ -68,8 +68,6 @@ retry:
++@@ -68,8 +68,6 @@
+  		release_firmware(fw);
+  		return size;
+  	}
+@@ -621,7 +621,7 @@
+  
+ --- a/drivers/media/pci/ngene/ngene-core.c
+ +++ b/drivers/media/pci/ngene/ngene-core.c
+-@@ -1236,19 +1236,14 @@ static int ngene_load_firm(struct ngene
++@@ -1236,19 +1236,14 @@
+  		break;
+  	}
+  
+@@ -644,7 +644,7 @@
+  	}
+ --- a/drivers/media/pci/saa7164/saa7164-fw.c
+ +++ b/drivers/media/pci/saa7164/saa7164-fw.c
+-@@ -405,11 +405,8 @@ int saa7164_downloadfirmware(struct saa7
++@@ -405,11 +405,8 @@
+  			__func__, fwname);
+  
+  		ret = request_firmware(&fw, fwname, &dev->pci->dev);
+@@ -659,7 +659,7 @@
+  			__func__, fw->size);
+ --- a/drivers/media/platform/samsung/s5p-mfc/s5p_mfc_ctrl.c
+ +++ b/drivers/media/platform/samsung/s5p-mfc/s5p_mfc_ctrl.c
+-@@ -65,10 +65,8 @@ int s5p_mfc_load_firmware(struct s5p_mfc
++@@ -65,10 +65,8 @@
+  		}
+  	}
+  
+@@ -673,7 +673,7 @@
+  		release_firmware(fw_blob);
+ --- a/drivers/media/radio/radio-wl1273.c
+ +++ b/drivers/media/radio/radio-wl1273.c
+-@@ -502,11 +502,8 @@ static int wl1273_fm_upload_firmware_pat
++@@ -502,11 +502,8 @@
+  	 * Uploading the firmware patch is not always necessary,
+  	 * so we only print an info message.
+  	 */
+@@ -688,7 +688,7 @@
+  	packet_num = ptr[0];
+ --- a/drivers/media/radio/wl128x/fmdrv_common.c
+ +++ b/drivers/media/radio/wl128x/fmdrv_common.c
+-@@ -1240,10 +1240,8 @@ static int fm_download_firmware(struct f
++@@ -1241,10 +1241,8 @@
+  
+  	ret = request_firmware(&fw_entry, fw_name,
+  				&fmdev->radio_dev->dev);
+@@ -702,7 +702,7 @@
+  	fw_data = (void *)fw_entry->data;
+ --- a/drivers/media/tuners/xc2028.c
+ +++ b/drivers/media/tuners/xc2028.c
+-@@ -1366,7 +1366,6 @@ static void load_firmware_cb(const struc
++@@ -1373,7 +1373,6 @@
+  
+  	tuner_dbg("request_firmware_nowait(): %s\n", fw ? "OK" : "error");
+  	if (!fw) {
+@@ -712,7 +712,7 @@
+  	}
+ --- a/drivers/media/usb/cx231xx/cx231xx-417.c
+ +++ b/drivers/media/usb/cx231xx/cx231xx-417.c
+-@@ -983,11 +983,6 @@ static int cx231xx_load_firmware(struct
++@@ -983,11 +983,6 @@
+  				  dev->dev);
+  
+  	if (retval != 0) {
+@@ -726,7 +726,7 @@
+  		return retval;
+ --- a/drivers/media/usb/dvb-usb/dib0700_devices.c
+ +++ b/drivers/media/usb/dvb-usb/dib0700_devices.c
+-@@ -2401,12 +2401,9 @@ static int stk9090m_frontend_attach(stru
++@@ -2401,12 +2401,9 @@
+  
+  	dib9000_i2c_enumeration(&adap->dev->i2c_adap, 1, 0x10, 0x80);
+  
+@@ -741,7 +741,7 @@
+  	stk9090m_config.microcode_B_fe_size = state->frontend_firmware->size;
+  	stk9090m_config.microcode_B_fe_buffer = state->frontend_firmware->data;
+  
+-@@ -2471,12 +2468,9 @@ static int nim9090md_frontend_attach(str
++@@ -2476,12 +2473,9 @@
+  	msleep(20);
+  	dib0700_set_gpio(adap->dev, GPIO0, GPIO_OUT, 1);
+  
+@@ -758,7 +758,7 @@
+  	nim9090md_config[1].microcode_B_fe_size = state->frontend_firmware->size;
+ --- a/drivers/media/usb/dvb-usb/dvb-usb-firmware.c
+ +++ b/drivers/media/usb/dvb-usb/dvb-usb-firmware.c
+-@@ -90,13 +90,9 @@ int dvb_usb_download_firmware(struct usb
++@@ -90,13 +90,9 @@
+  	int ret;
+  	const struct firmware *fw = NULL;
+  
+@@ -776,7 +776,7 @@
+  		case CYPRESS_AN2135:
+ --- a/drivers/media/usb/dvb-usb/gp8psk.c
+ +++ b/drivers/media/usb/dvb-usb/gp8psk.c
+-@@ -131,19 +131,14 @@ static int gp8psk_load_bcm4500fw(struct
++@@ -131,19 +131,14 @@
+  	const u8 *ptr;
+  	u8 *buf;
+  	if ((ret = request_firmware(&fw, bcm4500_firmware,
+@@ -799,7 +799,7 @@
+  	if (!buf) {
+ --- a/drivers/media/usb/dvb-usb/opera1.c
+ +++ b/drivers/media/usb/dvb-usb/opera1.c
+-@@ -459,8 +459,6 @@ static int opera1_xilinx_load_firmware(s
++@@ -459,8 +459,6 @@
+  	info("start downloading fpga firmware %s",filename);
+  
+  	if ((ret = request_firmware(&fw, filename, &dev->dev)) != 0) {
+@@ -810,7 +810,7 @@
+  		p = kmalloc(fw->size, GFP_KERNEL);
+ --- a/drivers/media/usb/go7007/go7007-driver.c
+ +++ b/drivers/media/usb/go7007/go7007-driver.c
+-@@ -84,10 +84,8 @@ static int go7007_load_encoder(struct go
++@@ -84,10 +84,8 @@
+  	u16 intr_val, intr_data;
+  
+  	if (go->boot_fw == NULL) {
+@@ -824,7 +824,7 @@
+  			release_firmware(fw_entry);
+ --- a/drivers/media/usb/go7007/go7007-fw.c
+ +++ b/drivers/media/usb/go7007/go7007-fw.c
+-@@ -1565,12 +1565,8 @@ int go7007_construct_fw_image(struct go7
++@@ -1565,12 +1565,8 @@
+  	default:
+  		return -1;
+  	}
+@@ -840,7 +840,7 @@
+  		goto fw_failed;
+ --- a/drivers/media/usb/go7007/go7007-loader.c
+ +++ b/drivers/media/usb/go7007/go7007-loader.c
+-@@ -67,11 +67,8 @@ static int go7007_loader_probe(struct us
++@@ -67,11 +67,8 @@
+  
+  	dev_info(&interface->dev, "loading firmware %s\n", fw1);
+  
+@@ -853,7 +853,7 @@
+  	ret = cypress_load_firmware(usbdev, fw, CYPRESS_FX2);
+  	release_firmware(fw);
+  	if (0 != ret) {
+-@@ -82,11 +79,8 @@ static int go7007_loader_probe(struct us
++@@ -82,11 +79,8 @@
+  	if (fw2 == NULL)
+  		return 0;
+  
+@@ -868,7 +868,7 @@
+  	if (0 != ret) {
+ --- a/drivers/media/usb/gspca/vicam.c
+ +++ b/drivers/media/usb/gspca/vicam.c
+-@@ -230,10 +230,8 @@ static int sd_init(struct gspca_dev *gsp
++@@ -230,10 +230,8 @@
+  
+  	ret = request_ihex_firmware(&fw, VICAM_FIRMWARE,
+  				    &gspca_dev->dev->dev);
+@@ -882,7 +882,7 @@
+  	if (!firmware_buf) {
+ --- a/drivers/media/usb/pvrusb2/pvrusb2-hdw.c
+ +++ b/drivers/media/usb/pvrusb2/pvrusb2-hdw.c
+-@@ -1370,25 +1370,6 @@ static int pvr2_locate_firmware(struct p
++@@ -1370,25 +1370,6 @@
+  			   "request_firmware fatal error with code=%d",ret);
+  		return ret;
+  	}
+@@ -910,7 +910,7 @@
+  
+ --- a/drivers/media/usb/s2255/s2255drv.c
+ +++ b/drivers/media/usb/s2255/s2255drv.c
+-@@ -2276,10 +2276,8 @@ static int s2255_probe(struct usb_interf
++@@ -2276,10 +2276,8 @@
+  	}
+  	/* load the first chunk */
+  	if (request_firmware(&dev->fw_data->fw,
+@@ -924,7 +924,7 @@
+  	pdata = (__le32 *) &dev->fw_data->fw->data[fw_size - 8];
+ --- a/drivers/media/usb/ttusb-budget/dvb-ttusb-budget.c
+ +++ b/drivers/media/usb/ttusb-budget/dvb-ttusb-budget.c
+-@@ -282,10 +282,8 @@ static int ttusb_boot_dsp(struct ttusb *
++@@ -282,10 +282,8 @@
+  
+  	err = request_firmware(&fw, "ttusb-budget/dspbootcode.bin",
+  			       &ttusb->dev->dev);
+@@ -938,7 +938,7 @@
+  	b[0] = 0xaa;
+ --- a/drivers/media/usb/ttusb-dec/ttusb_dec.c
+ +++ b/drivers/media/usb/ttusb-dec/ttusb_dec.c
+-@@ -1317,11 +1317,8 @@ static int ttusb_dec_boot_dsp(struct ttu
++@@ -1317,11 +1317,8 @@
+  	dprintk("%s\n", __func__);
+  
+  	result = request_firmware(&fw_entry, dec->firmware_name, &dec->udev->dev);
+@@ -953,7 +953,7 @@
+  	firmware_size = fw_entry->size;
+ --- a/drivers/misc/ti-st/st_kim.c
+ +++ b/drivers/misc/ti-st/st_kim.c
+-@@ -288,11 +288,8 @@ static long download_firmware(struct kim
++@@ -288,11 +288,8 @@
+  	    request_firmware(&kim_gdata->fw_entry, bts_scr_name,
+  			     &kim_gdata->kim_pdev->dev);
+  	if (unlikely((err != 0) || (kim_gdata->fw_entry->data == NULL) ||
+@@ -968,7 +968,7 @@
+  	/*
+ --- a/drivers/net/can/softing/softing_fw.c
+ +++ b/drivers/net/can/softing/softing_fw.c
+-@@ -226,11 +226,8 @@ int softing_load_app_fw(const char *file
++@@ -226,11 +226,8 @@
+  	int8_t type_end = 0, type_entrypoint = 0;
+  
+  	ret = request_firmware(&fw, file, &card->pdev->dev);
+@@ -983,7 +983,7 @@
+  	/* parse the firmware */
+ --- a/drivers/net/ethernet/3com/typhoon.c
+ +++ b/drivers/net/ethernet/3com/typhoon.c
+-@@ -1279,11 +1279,8 @@ typhoon_request_firmware(struct typhoon
++@@ -1279,11 +1279,8 @@
+  		return 0;
+  
+  	err = request_firmware(&typhoon_fw, FIRMWARE_NAME, &tp->pdev->dev);
+@@ -998,7 +998,7 @@
+  	remaining = typhoon_fw->size;
+ --- a/drivers/net/ethernet/adaptec/starfire.c
+ +++ b/drivers/net/ethernet/adaptec/starfire.c
+-@@ -1004,11 +1004,8 @@ static int netdev_open(struct net_device
++@@ -1004,11 +1004,8 @@
+  #endif /* VLAN_SUPPORT */
+  
+  	retval = request_firmware(&fw_rx, FIRMWARE_RX, &np->pci_dev->dev);
+@@ -1011,7 +1011,7 @@
+  	if (fw_rx->size % 4) {
+  		printk(KERN_ERR "starfire: bogus length %zu in \"%s\"\n",
+  		       fw_rx->size, FIRMWARE_RX);
+-@@ -1016,11 +1013,8 @@ static int netdev_open(struct net_device
++@@ -1016,11 +1013,8 @@
+  		goto out_rx;
+  	}
+  	retval = request_firmware(&fw_tx, FIRMWARE_TX, &np->pci_dev->dev);
+@@ -1026,7 +1026,7 @@
+  		       fw_tx->size, FIRMWARE_TX);
+ --- a/drivers/net/ethernet/alacritech/slicoss.c
+ +++ b/drivers/net/ethernet/alacritech/slicoss.c
+-@@ -1051,11 +1051,8 @@ static int slic_load_rcvseq_firmware(str
++@@ -1051,11 +1051,8 @@
+  	file = (sdev->model == SLIC_MODEL_OASIS) ?  SLIC_RCV_FIRMWARE_OASIS :
+  						    SLIC_RCV_FIRMWARE_MOJAVE;
+  	err = request_firmware(&fw, file, &sdev->pdev->dev);
+@@ -1039,7 +1039,7 @@
+  	/* Do an initial sanity check concerning firmware size now. A further
+  	 * check follows below.
+  	 */
+-@@ -1126,10 +1123,8 @@ static int slic_load_firmware(struct sli
++@@ -1126,10 +1123,8 @@
+  	file = (sdev->model == SLIC_MODEL_OASIS) ?  SLIC_FIRMWARE_OASIS :
+  						    SLIC_FIRMWARE_MOJAVE;
+  	err = request_firmware(&fw, file, &sdev->pdev->dev);
+@@ -1053,7 +1053,7 @@
+  	 */
+ --- a/drivers/net/ethernet/alteon/acenic.c
+ +++ b/drivers/net/ethernet/alteon/acenic.c
+-@@ -2877,11 +2877,8 @@ static int ace_load_firmware(struct net_
++@@ -2877,11 +2877,8 @@
+  		fw_name = "acenic/tg1.bin";
+  
+  	ret = request_firmware(&fw, fw_name, &ap->pdev->dev);
+@@ -1068,7 +1068,7 @@
+  
+ --- a/drivers/net/ethernet/broadcom/bnx2.c
+ +++ b/drivers/net/ethernet/broadcom/bnx2.c
+-@@ -3710,16 +3710,13 @@ static int bnx2_request_uncached_firmwar
++@@ -3710,16 +3710,13 @@
+  	}
+  
+  	rc = request_firmware(&bp->mips_firmware, mips_fw_file, &bp->pdev->dev);
+@@ -1090,7 +1090,7 @@
+  	if (bp->mips_firmware->size < sizeof(*mips_fw) ||
+ --- a/drivers/net/ethernet/broadcom/tg3.c
+ +++ b/drivers/net/ethernet/broadcom/tg3.c
+-@@ -11394,11 +11394,8 @@ static int tg3_request_firmware(struct t
++@@ -11412,11 +11412,8 @@
+  {
+  	const struct tg3_firmware_hdr *fw_hdr;
+  
+@@ -1105,7 +1105,7 @@
+  
+ --- a/drivers/net/ethernet/brocade/bna/cna_fwimg.c
+ +++ b/drivers/net/ethernet/brocade/bna/cna_fwimg.c
+-@@ -24,10 +24,8 @@ cna_read_firmware(struct pci_dev *pdev,
++@@ -24,10 +24,8 @@
+  	const struct firmware *fw;
+  	u32 n;
+  
+@@ -1119,7 +1119,7 @@
+  	*bfi_image_size = fw->size/sizeof(u32);
+ --- a/drivers/net/ethernet/chelsio/cxgb3/cxgb3_main.c
+ +++ b/drivers/net/ethernet/chelsio/cxgb3/cxgb3_main.c
+-@@ -1035,12 +1035,8 @@ int t3_get_edc_fw(struct cphy *phy, int
++@@ -1035,12 +1035,8 @@
+  	fw_name = get_edc_fw_name(edc_idx);
+  	if (fw_name)
+  		ret = request_firmware(&fw, fw_name, &adapter->pdev->dev);
+@@ -1133,7 +1133,7 @@
+  
+  	/* check size, take checksum in account */
+  	if (fw->size > size + 4) {
+-@@ -1077,11 +1073,8 @@ static int upgrade_fw(struct adapter *ad
++@@ -1077,11 +1073,8 @@
+  	struct device *dev = &adap->pdev->dev;
+  
+  	ret = request_firmware(&fw, FW_FNAME, dev);
+@@ -1146,7 +1146,7 @@
+  	ret = t3_load_fw(adap, fw->data, fw->size);
+  	release_firmware(fw);
+  
+-@@ -1126,11 +1119,8 @@ static int update_tpsram(struct adapter
++@@ -1126,11 +1119,8 @@
+  	snprintf(buf, sizeof(buf), TPSRAM_NAME, rev);
+  
+  	ret = request_firmware(&tpsram, buf, dev);
+@@ -1161,7 +1161,7 @@
+  	if (ret)
+ --- a/drivers/net/ethernet/intel/e100.c
+ +++ b/drivers/net/ethernet/intel/e100.c
+-@@ -1262,9 +1262,6 @@ static const struct firmware *e100_reque
++@@ -1262,9 +1262,6 @@
+  
+  	if (err) {
+  		if (required) {
+@@ -1173,7 +1173,7 @@
+  			netif_info(nic, probe, nic->netdev,
+ --- a/drivers/net/ethernet/myricom/myri10ge/myri10ge.c
+ +++ b/drivers/net/ethernet/myricom/myri10ge/myri10ge.c
+-@@ -580,8 +580,6 @@ static int myri10ge_load_hotplug_firmwar
++@@ -580,8 +580,6 @@
+  	unsigned i;
+  
+  	if (request_firmware(&fw, mgp->fw_name, dev) < 0) {
+@@ -1184,7 +1184,7 @@
+  	}
+ --- a/drivers/net/ethernet/smsc/smc91c92_cs.c
+ +++ b/drivers/net/ethernet/smsc/smc91c92_cs.c
+-@@ -651,10 +651,8 @@ static int osi_load_firmware(struct pcmc
++@@ -651,10 +651,8 @@
+  	int i, err;
+  
+  	err = request_firmware(&fw, FIRMWARE_NAME, &link->dev);
+@@ -1198,7 +1198,7 @@
+  	for (i = 0; i < fw->size; i++) {
+ --- a/drivers/net/ethernet/sun/cassini.c
+ +++ b/drivers/net/ethernet/sun/cassini.c
+-@@ -792,11 +792,8 @@ static void cas_saturn_firmware_init(str
++@@ -792,11 +792,8 @@
+  		return;
+  
+  	err = request_firmware(&fw, fw_name, &cp->pdev->dev);
+@@ -1213,7 +1213,7 @@
+  		       fw->size, fw_name);
+ --- a/drivers/net/hamradio/yam.c
+ +++ b/drivers/net/hamradio/yam.c
+-@@ -357,11 +357,8 @@ static unsigned char *add_mcs(unsigned c
++@@ -357,11 +357,8 @@
+  		}
+  		err = request_firmware(&fw, fw_name[predef], &pdev->dev);
+  		platform_device_unregister(pdev);
+@@ -1228,7 +1228,7 @@
+  			       fw->size, fw_name[predef]);
+ --- a/drivers/net/usb/kaweth.c
+ +++ b/drivers/net/usb/kaweth.c
+-@@ -305,10 +305,8 @@ static int kaweth_download_firmware(stru
++@@ -305,10 +305,8 @@
+  	int ret;
+  
+  	ret = request_firmware(&fw, fwname, &kaweth->dev->dev);
+@@ -1242,7 +1242,7 @@
+  		dev_err(&kaweth->intf->dev, "Firmware too big: %zu\n",
+ --- a/drivers/net/wireless/ath/ath9k/hif_usb.c
+ +++ b/drivers/net/wireless/ath/ath9k/hif_usb.c
+-@@ -1250,9 +1250,6 @@ static void ath9k_hif_usb_firmware_cb(co
++@@ -1248,9 +1248,6 @@
+  		if (!ret)
+  			return;
+  
+@@ -1254,7 +1254,7 @@
+  
+ --- a/drivers/net/wireless/ath/carl9170/usb.c
+ +++ b/drivers/net/wireless/ath/carl9170/usb.c
+-@@ -1029,7 +1029,6 @@ static void carl9170_usb_firmware_step2(
++@@ -1029,7 +1029,6 @@
+  		return;
+  	}
+  
+@@ -1264,7 +1264,7 @@
+  
+ --- a/drivers/net/wireless/atmel/at76c50x-usb.c
+ +++ b/drivers/net/wireless/atmel/at76c50x-usb.c
+-@@ -1616,13 +1616,8 @@ static struct fwentry *at76_load_firmwar
++@@ -1616,13 +1616,8 @@
+  
+  	at76_dbg(DBG_FW, "downloading firmware %s", fwe->fwname);
+  	ret = request_firmware(&fwe->fw, fwe->fwname, &udev->dev);
+@@ -1281,7 +1281,7 @@
+  	fwh = (struct at76_fw_header *)(fwe->fw->data);
+ --- a/drivers/net/wireless/atmel/atmel.c
+ +++ b/drivers/net/wireless/atmel/atmel.c
+-@@ -3892,12 +3892,8 @@ static int reset_atmel_card(struct net_d
++@@ -3892,12 +3892,8 @@
+  					strcpy(priv->firmware_id, "atmel_at76c502.bin");
+  				}
+  				err = request_firmware(&fw_entry, priv->firmware_id, priv->sys_dev);
+@@ -1297,7 +1297,7 @@
+  				int success = 0;
+ --- a/drivers/net/wireless/broadcom/b43/main.c
+ +++ b/drivers/net/wireless/broadcom/b43/main.c
+-@@ -2245,19 +2245,8 @@ int b43_do_request_fw(struct b43_request
++@@ -2245,19 +2245,8 @@
+  	}
+  	err = request_firmware(&ctx->blob, ctx->fwname,
+  			       ctx->dev->dev->dev);
+@@ -1320,7 +1320,7 @@
+  		goto err_format;
+ --- a/drivers/net/wireless/broadcom/b43legacy/main.c
+ +++ b/drivers/net/wireless/broadcom/b43legacy/main.c
+-@@ -1524,11 +1524,8 @@ static int do_request_fw(struct b43legac
++@@ -1524,11 +1524,8 @@
+  	} else {
+  		err = request_firmware(fw, path, dev->dev->dev);
+  	}
+@@ -1335,7 +1335,7 @@
+  	hdr = (struct b43legacy_fw_header *)((*fw)->data);
+ --- a/drivers/net/wireless/broadcom/brcm80211/brcmsmac/mac80211_if.c
+ +++ b/drivers/net/wireless/broadcom/brcm80211/brcmsmac/mac80211_if.c
+-@@ -376,19 +376,13 @@ static int brcms_request_fw(struct brcms
++@@ -376,19 +376,13 @@
+  		sprintf(fw_name, "%s-%d.fw", brcms_firmwares[i],
+  			UCODE_LOADER_API_VER);
+  		status = request_firmware(&wl->fw.fw_bin[i], fw_name, device);
+@@ -1359,7 +1359,7 @@
+  	}
+ --- a/drivers/net/wireless/intel/ipw2x00/ipw2100.c
+ +++ b/drivers/net/wireless/intel/ipw2x00/ipw2100.c
+-@@ -8359,12 +8359,8 @@ static int ipw2100_get_firmware(struct i
++@@ -8359,12 +8359,8 @@
+  
+  	rc = request_firmware(&fw->fw_entry, fw_name, &priv->pci_dev->dev);
+  
+@@ -1375,7 +1375,7 @@
+  
+ --- a/drivers/net/wireless/intel/ipw2x00/ipw2200.c
+ +++ b/drivers/net/wireless/intel/ipw2x00/ipw2200.c
+-@@ -3350,10 +3350,8 @@ static int ipw_get_fw(struct ipw_priv *p
++@@ -3350,10 +3350,8 @@
+  
+  	/* ask firmware_class module to get the boot firmware off disk */
+  	rc = request_firmware(raw, name, &priv->pci_dev->dev);
+@@ -1389,7 +1389,7 @@
+  		IPW_ERROR("%s is too small (%zd)\n", name, (*raw)->size);
+ --- a/drivers/net/wireless/intel/iwlegacy/3945-mac.c
+ +++ b/drivers/net/wireless/intel/iwlegacy/3945-mac.c
+-@@ -1829,7 +1829,6 @@ il3945_read_ucode(struct il_priv *il)
++@@ -1829,7 +1829,6 @@
+  		sprintf(buf, "%s%u%s", name_pre, idx, ".ucode");
+  		ret = request_firmware(&ucode_raw, buf, &il->pci_dev->dev);
+  		if (ret < 0) {
+@@ -1399,7 +1399,7 @@
+  			else
+ --- a/drivers/net/wireless/intel/iwlwifi/iwl-drv.c
+ +++ b/drivers/net/wireless/intel/iwlwifi/iwl-drv.c
+-@@ -241,8 +241,6 @@ static int iwl_request_firmware(struct i
++@@ -242,8 +242,6 @@
+  		drv->fw_index--;
+  
+  	if (drv->fw_index < cfg->ucode_api_min) {
+@@ -1410,7 +1410,7 @@
+  				cfg->ucode_api_max);
+ --- a/drivers/net/wireless/intersil/orinoco/fw.c
+ +++ b/drivers/net/wireless/intersil/orinoco/fw.c
+-@@ -132,7 +132,6 @@ orinoco_dl_firmware(struct orinoco_priva
++@@ -132,7 +132,6 @@
+  		err = request_firmware(&fw_entry, firmware, priv->dev);
+  
+  		if (err) {
+@@ -1418,7 +1418,7 @@
+  			err = -ENOENT;
+  			goto free;
+  		}
+-@@ -292,10 +291,8 @@ symbol_dl_firmware(struct orinoco_privat
++@@ -292,10 +291,8 @@
+  	const struct firmware *fw_entry;
+  
+  	if (!orinoco_cached_fw_get(priv, true)) {
+@@ -1430,7 +1430,7 @@
+  	} else
+  		fw_entry = orinoco_cached_fw_get(priv, true);
+  
+-@@ -311,10 +308,8 @@ symbol_dl_firmware(struct orinoco_privat
++@@ -311,10 +308,8 @@
+  	}
+  
+  	if (!orinoco_cached_fw_get(priv, false)) {
+@@ -1444,7 +1444,7 @@
+  
+ --- a/drivers/net/wireless/intersil/orinoco/orinoco_usb.c
+ +++ b/drivers/net/wireless/intersil/orinoco/orinoco_usb.c
+-@@ -1708,7 +1708,6 @@ static int ezusb_probe(struct usb_interf
++@@ -1708,7 +1708,6 @@
+  		if (ezusb_firmware_download(upriv, &firmware) < 0)
+  			goto error;
+  	} else {
+@@ -1454,7 +1454,7 @@
+  
+ --- a/drivers/net/wireless/intersil/p54/p54pci.c
+ +++ b/drivers/net/wireless/intersil/p54/p54pci.c
+-@@ -502,7 +502,6 @@ static void p54p_firmware_step2(const st
++@@ -502,7 +502,6 @@
+  	int err;
+  
+  	if (!fw) {
+@@ -1464,7 +1464,7 @@
+  	}
+ --- a/drivers/net/wireless/intersil/p54/p54spi.c
+ +++ b/drivers/net/wireless/intersil/p54/p54spi.c
+-@@ -158,10 +158,8 @@ static int p54spi_request_firmware(struc
++@@ -158,10 +158,8 @@
+  	/* FIXME: should driver use it's own struct device? */
+  	ret = request_firmware(&priv->firmware, "3826.arm", &priv->spi->dev);
+  
+@@ -1478,7 +1478,7 @@
+  	if (ret) {
+ --- a/drivers/net/wireless/intersil/p54/p54usb.c
+ +++ b/drivers/net/wireless/intersil/p54/p54usb.c
+-@@ -929,7 +929,6 @@ static void p54u_load_firmware_cb(const
++@@ -929,7 +929,6 @@
+  		err = p54u_start_ops(priv);
+  	} else {
+  		err = -ENOENT;
+@@ -1488,7 +1488,7 @@
+  	complete(&priv->fw_wait_load);
+ --- a/drivers/net/wireless/marvell/libertas_tf/if_usb.c
+ +++ b/drivers/net/wireless/marvell/libertas_tf/if_usb.c
+-@@ -820,8 +820,6 @@ static int if_usb_prog_firmware(struct l
++@@ -820,8 +820,6 @@
+  	kernel_param_lock(THIS_MODULE);
+  	ret = request_firmware(&cardp->fw, lbtf_fw_name, &cardp->udev->dev);
+  	if (ret < 0) {
+@@ -1499,7 +1499,7 @@
+  	}
+ --- a/drivers/net/wireless/marvell/mwifiex/main.c
+ +++ b/drivers/net/wireless/marvell/mwifiex/main.c
+-@@ -549,11 +549,8 @@ static int _mwifiex_fw_dpc(const struct
++@@ -549,11 +549,8 @@
+  	struct wireless_dev *wdev;
+  	struct completion *fw_done = adapter->fw_done;
+  
+@@ -1514,7 +1514,7 @@
+  	adapter->firmware = firmware;
+ --- a/drivers/net/wireless/marvell/mwl8k.c
+ +++ b/drivers/net/wireless/marvell/mwl8k.c
+-@@ -5736,16 +5736,12 @@ static int mwl8k_firmware_load_success(s
++@@ -5736,16 +5736,12 @@
+  static void mwl8k_fw_state_machine(const struct firmware *fw, void *context)
+  {
+  	struct mwl8k_priv *priv = context;
+@@ -1532,7 +1532,7 @@
+  		priv->fw_helper = fw;
+  		rc = mwl8k_request_fw(priv, priv->fw_pref, &priv->fw_ucode,
+  				      true);
+-@@ -5780,11 +5776,8 @@ static void mwl8k_fw_state_machine(const
++@@ -5780,11 +5776,8 @@
+  		break;
+  
+  	case FW_STATE_LOADING_ALT:
+@@ -1545,7 +1545,7 @@
+  		priv->fw_ucode = fw;
+  		rc = mwl8k_firmware_load_success(priv);
+  		if (rc)
+-@@ -5822,10 +5815,8 @@ retry:
++@@ -5822,10 +5815,8 @@
+  
+  	/* Ask userland hotplug daemon for the device firmware */
+  	rc = mwl8k_request_firmware(priv, fw_image, nowait);
+@@ -1559,7 +1559,7 @@
+  		return rc;
+ --- a/drivers/net/wireless/ralink/rt2x00/rt2x00firmware.c
+ +++ b/drivers/net/wireless/ralink/rt2x00/rt2x00firmware.c
+-@@ -38,10 +38,8 @@ static int rt2x00lib_request_firmware(st
++@@ -38,10 +38,8 @@
+  	rt2x00_info(rt2x00dev, "Loading firmware file '%s'\n", fw_name);
+  
+  	retval = request_firmware(&fw, fw_name, device);
+@@ -1573,7 +1573,7 @@
+  		rt2x00_err(rt2x00dev, "Failed to read Firmware\n");
+ --- a/drivers/net/wireless/realtek/rtlwifi/core.c
+ +++ b/drivers/net/wireless/realtek/rtlwifi/core.c
+-@@ -88,7 +88,6 @@ static void rtl_fw_do_work(const struct
++@@ -88,7 +88,6 @@
+  			if (!err)
+  				goto found_alt;
+  		}
+@@ -1581,25 +1581,9 @@
+  		rtlpriv->max_fw_size = 0;
+  		goto exit;
+  	}
+---- a/drivers/net/wireless/realtek/rtlwifi/rtl8192se/sw.c
+-+++ b/drivers/net/wireless/realtek/rtlwifi/rtl8192se/sw.c
+-@@ -63,13 +63,11 @@ static void rtl92se_fw_cb(const struct f
+- 	struct ieee80211_hw *hw = context;
+- 	struct rtl_priv *rtlpriv = rtl_priv(hw);
+- 	struct rt_firmware *pfirmware = NULL;
+--	char *fw_name = "rtlwifi/rtl8192sefw.bin";
+- 
+- 	rtl_dbg(rtlpriv, COMP_ERR, DBG_LOUD,
+- 		"Firmware callback routine entered!\n");
+- 	complete(&rtlpriv->firmware_loading_complete);
+- 	if (!firmware) {
+--		pr_err("Firmware %s not available\n", fw_name);
+- 		rtlpriv->max_fw_size = 0;
+- 		return;
+- 	}
+ --- a/drivers/net/wireless/ti/wl1251/main.c
+ +++ b/drivers/net/wireless/ti/wl1251/main.c
+-@@ -57,10 +57,8 @@ static int wl1251_fetch_firmware(struct
++@@ -57,10 +57,8 @@
+  
+  	ret = request_firmware(&fw, WL1251_FW_NAME, dev);
+  
+@@ -1611,7 +1595,7 @@
+  
+  	if (fw->size % 4) {
+  		wl1251_error("firmware size is not multiple of 32 bits: %zu",
+-@@ -96,10 +94,8 @@ static int wl1251_fetch_nvs(struct wl125
++@@ -96,10 +94,8 @@
+  
+  	ret = request_firmware(&fw, WL1251_NVS_NAME, dev);
+  
+@@ -1625,7 +1609,7 @@
+  		wl1251_error("nvs size is not multiple of 32 bits: %zu",
+ --- a/drivers/net/wireless/ti/wlcore/main.c
+ +++ b/drivers/net/wireless/ti/wlcore/main.c
+-@@ -756,10 +756,8 @@ static int wl12xx_fetch_firmware(struct
++@@ -756,10 +756,8 @@
+  
+  	ret = request_firmware(&fw, fw_name, wl->dev);
+  
+@@ -1639,7 +1623,7 @@
+  		wl1271_error("firmware size is not multiple of 32 bits: %zu",
+ --- a/drivers/net/wireless/zydas/zd1201.c
+ +++ b/drivers/net/wireless/zydas/zd1201.c
+-@@ -62,8 +62,6 @@ static int zd1201_fw_upload(struct usb_d
++@@ -62,8 +62,6 @@
+  
+  	err = request_firmware(&fw_entry, fwfile, &dev->dev);
+  	if (err) {
+@@ -1650,7 +1634,7 @@
+  	}
+ --- a/drivers/net/wireless/zydas/zd1211rw/zd_usb.c
+ +++ b/drivers/net/wireless/zydas/zd1211rw/zd_usb.c
+-@@ -107,16 +107,9 @@ static void int_urb_complete(struct urb
++@@ -107,16 +107,9 @@
+  static int request_fw_file(
+  	const struct firmware **fw, const char *name, struct device *device)
+  {
+@@ -1670,7 +1654,7 @@
+  static inline u16 get_bcdDevice(const struct usb_device *udev)
+ --- a/drivers/scsi/advansys.c
+ +++ b/drivers/scsi/advansys.c
+-@@ -4054,8 +4054,6 @@ static int AscInitAsc1000Driver(ASC_DVC_
++@@ -4054,8 +4054,6 @@
+  
+  	err = request_firmware(&fw, fwname, asc_dvc->drv_ptr->dev);
+  	if (err) {
+@@ -1679,7 +1663,7 @@
+  		asc_dvc->err_code |= ASC_IERR_MCODE_CHKSUM;
+  		return err;
+  	}
+-@@ -4420,8 +4418,6 @@ static int AdvInitAsc3550Driver(ADV_DVC_
++@@ -4420,8 +4418,6 @@
+  
+  	err = request_firmware(&fw, fwname, asc_dvc->drv_ptr->dev);
+  	if (err) {
+@@ -1688,7 +1672,7 @@
+  		asc_dvc->err_code = ASC_IERR_MCODE_CHKSUM;
+  		return err;
+  	}
+-@@ -4920,8 +4916,6 @@ static int AdvInitAsc38C0800Driver(ADV_D
++@@ -4920,8 +4916,6 @@
+  
+  	err = request_firmware(&fw, fwname, asc_dvc->drv_ptr->dev);
+  	if (err) {
+@@ -1697,7 +1681,7 @@
+  		asc_dvc->err_code = ASC_IERR_MCODE_CHKSUM;
+  		return err;
+  	}
+-@@ -5408,8 +5402,6 @@ static int AdvInitAsc38C1600Driver(ADV_D
++@@ -5408,8 +5402,6 @@
+  
+  	err = request_firmware(&fw, fwname, asc_dvc->drv_ptr->dev);
+  	if (err) {
+@@ -1708,7 +1692,7 @@
+  	}
+ --- a/drivers/scsi/aic94xx/aic94xx_init.c
+ +++ b/drivers/scsi/aic94xx/aic94xx_init.c
+-@@ -370,8 +370,6 @@ static ssize_t asd_store_update_bios(str
++@@ -370,8 +370,6 @@
+  				   filename_ptr,
+  				   &asd_ha->pcidev->dev);
+  	if (err) {
+@@ -1719,7 +1703,7 @@
+  	}
+ --- a/drivers/scsi/aic94xx/aic94xx_seq.c
+ +++ b/drivers/scsi/aic94xx/aic94xx_seq.c
+-@@ -1302,11 +1302,8 @@ int asd_init_seqs(struct asd_ha_struct *
++@@ -1302,11 +1302,8 @@
+  
+  	err = asd_request_firmware(asd_ha);
+  
+@@ -1734,7 +1718,7 @@
+  	if (err) {
+ --- a/drivers/scsi/bfa/bfad.c
+ +++ b/drivers/scsi/bfa/bfad.c
+-@@ -1737,7 +1737,6 @@ bfad_read_firmware(struct pci_dev *pdev,
++@@ -1736,7 +1736,6 @@
+  	const struct firmware *fw;
+  
+  	if (request_firmware(&fw, fw_name, &pdev->dev)) {
+@@ -1744,7 +1728,7 @@
+  	}
+ --- a/drivers/scsi/ipr.c
+ +++ b/drivers/scsi/ipr.c
+-@@ -4009,10 +4009,8 @@ static ssize_t ipr_store_update_fw(struc
++@@ -4009,10 +4009,8 @@
+  	if (endline)
+  		*endline = '\0';
+  
+@@ -1758,7 +1742,7 @@
+  
+ --- a/drivers/scsi/pm8001/pm8001_ctl.c
+ +++ b/drivers/scsi/pm8001/pm8001_ctl.c
+-@@ -842,9 +842,6 @@ static ssize_t pm8001_store_update_fw(st
++@@ -842,9 +842,6 @@
+  			       pm8001_ha->dev);
+  
+  	if (ret) {
+@@ -1770,7 +1754,7 @@
+  	}
+ --- a/drivers/scsi/qla1280.c
+ +++ b/drivers/scsi/qla1280.c
+-@@ -1504,8 +1504,6 @@ qla1280_request_firmware(struct scsi_qla
++@@ -1504,8 +1504,6 @@
+  	err = request_firmware(&fw, fwname, &ha->pdev->dev);
+  
+  	if (err) {
+@@ -1781,7 +1765,7 @@
+  	}
+ --- a/drivers/scsi/qla2xxx/qla_init.c
+ +++ b/drivers/scsi/qla2xxx/qla_init.c
+-@@ -8560,10 +8560,6 @@ qla2x00_load_risc(scsi_qla_host_t *vha,
++@@ -8610,10 +8610,6 @@
+  	/* Load firmware blob. */
+  	blob = qla2x00_request_firmware(vha);
+  	if (!blob) {
+@@ -1792,7 +1776,7 @@
+  		return QLA_FUNCTION_FAILED;
+  	}
+  
+-@@ -8666,9 +8662,6 @@ qla24xx_load_risc_blob(scsi_qla_host_t *
++@@ -8716,9 +8712,6 @@
+  
+  	blob = qla2x00_request_firmware(vha);
+  	if (!blob) {
+@@ -1804,7 +1788,7 @@
+  
+ --- a/drivers/scsi/qla2xxx/qla_nx.c
+ +++ b/drivers/scsi/qla2xxx/qla_nx.c
+-@@ -2427,11 +2427,8 @@ try_blob_fw:
++@@ -2427,11 +2427,8 @@
+  
+  	/* Load firmware blob. */
+  	blob = ha->hablob = qla2x00_request_firmware(vha);
+@@ -1819,7 +1803,7 @@
+  	if (qla82xx_validate_firmware_blob(vha,
+ --- a/drivers/scsi/qla2xxx/qla_os.c
+ +++ b/drivers/scsi/qla2xxx/qla_os.c
+-@@ -7696,8 +7696,6 @@ qla2x00_request_firmware(scsi_qla_host_t
++@@ -7697,8 +7697,6 @@
+  		goto out;
+  
+  	if (request_firmware(&blob->fw, blob->name, &ha->pdev->dev)) {
+@@ -1830,7 +1814,7 @@
+  	}
+ --- a/drivers/scsi/qlogicpti.c
+ +++ b/drivers/scsi/qlogicpti.c
+-@@ -486,11 +486,8 @@ static int qlogicpti_load_firmware(struc
++@@ -486,11 +486,8 @@
+  	int i, timeout;
+  
+  	err = request_firmware(&fw, fwname, &qpti->op->dev);
+@@ -1845,7 +1829,7 @@
+  		       fw->size, fwname);
+ --- a/drivers/staging/rtl8192u/r819xU_firmware.c
+ +++ b/drivers/staging/rtl8192u/r819xU_firmware.c
+-@@ -240,10 +240,8 @@ bool init_firmware(struct net_device *de
++@@ -240,10 +240,8 @@
+  		 */
+  		if (rst_opt == OPT_SYSTEM_RESET) {
+  			rc = request_firmware(&fw_entry, fw_name[init_step], &priv->udev->dev);
+@@ -1859,7 +1843,7 @@
+  				RT_TRACE(COMP_ERR, "img file size exceed the container buffer fail!\n");
+ --- a/drivers/staging/rtl8712/hal_init.c
+ +++ b/drivers/staging/rtl8712/hal_init.c
+-@@ -72,8 +72,6 @@ int rtl871x_load_fw(struct _adapter *pad
++@@ -72,8 +72,6 @@
+  	dev_info(dev, "r8712u: Loading firmware from \"%s\"\n", firmware_file);
+  	rc = request_firmware_nowait(THIS_MODULE, 1, firmware_file, dev,
+  				     GFP_KERNEL, padapter, rtl871x_load_fw_cb);
+@@ -1870,7 +1854,7 @@
+  MODULE_FIRMWARE("rtlwifi/rtl8712u.bin");
+ --- a/drivers/staging/vt6656/main_usb.c
+ +++ b/drivers/staging/vt6656/main_usb.c
+-@@ -107,11 +107,8 @@ static int vnt_download_firmware(struct
++@@ -107,11 +107,8 @@
+  	dev_dbg(dev, "---->Download firmware\n");
+  
+  	ret = request_firmware(&fw, FIRMWARE_NAME, dev);
+@@ -1885,7 +1869,7 @@
+  		length = min_t(int, fw->size - ii, FIRMWARE_CHUNK_SIZE);
+ --- a/drivers/tty/moxa.c
+ +++ b/drivers/tty/moxa.c
+-@@ -1154,13 +1154,8 @@ static int moxa_init_board(struct moxa_b
++@@ -1154,13 +1154,8 @@
+  	}
+  
+  	ret = request_firmware(&fw, file, dev);
+@@ -1902,7 +1886,7 @@
+  
+ --- a/drivers/tty/serial/icom.c
+ +++ b/drivers/tty/serial/icom.c
+-@@ -621,7 +621,6 @@ static void load_code(struct icom_port *
++@@ -621,7 +621,6 @@
+  
+  	/* Load Call Setup into Adapter */
+  	if (request_firmware(&fw, "icom_call_setup.bin", &dev->dev) < 0) {
+@@ -1910,7 +1894,7 @@
+  		status = -1;
+  		goto load_code_exit;
+  	}
+-@@ -641,7 +640,6 @@ static void load_code(struct icom_port *
++@@ -641,7 +640,6 @@
+  
+  	/* Load Resident DCE portion of Adapter */
+  	if (request_firmware(&fw, "icom_res_dce.bin", &dev->dev) < 0) {
+@@ -1918,7 +1902,7 @@
+  		status = -1;
+  		goto load_code_exit;
+  	}
+-@@ -686,7 +684,6 @@ static void load_code(struct icom_port *
++@@ -686,7 +684,6 @@
+  	}
+  
+  	if (request_firmware(&fw, "icom_asc.bin", &dev->dev) < 0) {
+@@ -1928,7 +1912,7 @@
+  	}
+ --- a/drivers/tty/serial/ucc_uart.c
+ +++ b/drivers/tty/serial/ucc_uart.c
+-@@ -1149,10 +1149,8 @@ static void uart_firmware_cont(const str
++@@ -1149,10 +1149,8 @@
+  	struct device *dev = context;
+  	int ret;
+  
+@@ -1942,7 +1926,7 @@
+  
+ --- a/drivers/usb/atm/cxacru.c
+ +++ b/drivers/usb/atm/cxacru.c
+-@@ -1084,8 +1084,6 @@ static int cxacru_find_firmware(struct c
++@@ -1084,8 +1084,6 @@
+  		return -ENOENT;
+  	}
+  
+@@ -1953,7 +1937,7 @@
+  
+ --- a/drivers/usb/atm/ueagle-atm.c
+ +++ b/drivers/usb/atm/ueagle-atm.c
+-@@ -606,10 +606,8 @@ static void uea_upload_pre_firmware(cons
++@@ -606,10 +606,8 @@
+  	int ret, size;
+  
+  	uea_enters(usb);
+@@ -1965,7 +1949,7 @@
+  
+  	pfw = fw_entry->data;
+  	size = fw_entry->size;
+-@@ -704,10 +702,6 @@ static int uea_load_firmware(struct usb_
++@@ -704,10 +702,6 @@
+  	ret = request_firmware_nowait(THIS_MODULE, 1, fw_name, &usb->dev,
+  					GFP_KERNEL, usb,
+  					uea_upload_pre_firmware);
+@@ -1976,7 +1960,7 @@
+  
+  	uea_leaves(usb);
+  	return ret;
+-@@ -869,12 +863,8 @@ static int request_dsp(struct uea_softc
++@@ -869,12 +863,8 @@
+  	}
+  
+  	ret = request_firmware(&sc->dsp_firm, dsp_name, &sc->usb_dev->dev);
+@@ -1990,7 +1974,7 @@
+  
+  	if (UEA_CHIP_VERSION(sc) == EAGLE_IV)
+  		ret = check_dsp_e4(sc->dsp_firm->data, sc->dsp_firm->size);
+-@@ -1587,12 +1577,8 @@ static int request_cmvs_old(struct uea_s
++@@ -1587,12 +1577,8 @@
+  
+  	cmvs_file_name(sc, cmv_name, 1);
+  	ret = request_firmware(fw, cmv_name, &sc->usb_dev->dev);
+@@ -2004,7 +1988,7 @@
+  
+  	data = (u8 *) (*fw)->data;
+  	size = (*fw)->size;
+-@@ -1629,9 +1615,6 @@ static int request_cmvs(struct uea_softc
++@@ -1629,9 +1615,6 @@
+  				"try to get older cmvs\n", cmv_name);
+  			return request_cmvs_old(sc, cmvs, fw);
+  		}
+@@ -2014,7 +1998,7 @@
+  		return ret;
+  	}
+  
+-@@ -1914,11 +1897,8 @@ static int load_XILINX_firmware(struct u
++@@ -1914,11 +1897,8 @@
+  	uea_enters(INS_TO_USBDEV(sc));
+  
+  	ret = request_firmware(&fw_entry, fw_name, &sc->usb_dev->dev);
+@@ -2029,7 +2013,7 @@
+  	size = fw_entry->size;
+ --- a/drivers/usb/misc/emi26.c
+ +++ b/drivers/usb/misc/emi26.c
+-@@ -85,21 +85,17 @@ static int emi26_load_firmware (struct u
++@@ -85,21 +85,17 @@
+  
+  	err = request_ihex_firmware(&loader_fw, "emi26/loader.fw", &dev->dev);
+  	if (err)
+@@ -2056,7 +2040,7 @@
+  	err = emi26_set_reset(dev,1);
+ --- a/drivers/usb/misc/ezusb.c
+ +++ b/drivers/usb/misc/ezusb.c
+-@@ -64,12 +64,8 @@ static int ezusb_ihex_firmware_download(
++@@ -64,12 +64,8 @@
+  	const struct ihex_binrec *record;
+  
+  	if (request_ihex_firmware(&firmware, firmware_path,
+@@ -2072,7 +2056,7 @@
+  	if (ret < 0)
+ --- a/drivers/usb/misc/isight_firmware.c
+ +++ b/drivers/usb/misc/isight_firmware.c
+-@@ -45,7 +45,6 @@ static int isight_firmware_load(struct u
++@@ -45,7 +45,6 @@
+  		return -ENOMEM;
+  
+  	if (request_firmware(&firmware, "isight.fw", &dev->dev) != 0) {
+@@ -2082,7 +2066,7 @@
+  	}
+ --- a/drivers/usb/serial/io_edgeport.c
+ +++ b/drivers/usb/serial/io_edgeport.c
+-@@ -332,11 +332,8 @@ static void update_edgeport_E2PROM(struc
++@@ -332,11 +332,8 @@
+  
+  	response = request_ihex_firmware(&fw, fw_name,
+  					 &edge_serial->serial->dev->dev);
+@@ -2097,7 +2081,7 @@
+  	BootMajorVersion = rec->data[0];
+ --- a/drivers/usb/serial/io_ti.c
+ +++ b/drivers/usb/serial/io_ti.c
+-@@ -1009,8 +1009,6 @@ static int download_fw(struct edgeport_s
++@@ -1009,8 +1009,6 @@
+  
+  	status = request_firmware(&fw, fw_name, dev);
+  	if (status) {
+@@ -2108,7 +2092,7 @@
+  
+ --- a/drivers/usb/serial/ti_usb_3410_5052.c
+ +++ b/drivers/usb/serial/ti_usb_3410_5052.c
+-@@ -1635,10 +1635,8 @@ static int ti_download_firmware(struct t
++@@ -1635,10 +1635,8 @@
+  	}
+  
+  check_firmware:
+@@ -2122,7 +2106,7 @@
+  		release_firmware(fw_p);
+ --- a/drivers/video/fbdev/broadsheetfb.c
+ +++ b/drivers/video/fbdev/broadsheetfb.c
+-@@ -743,10 +743,8 @@ static ssize_t broadsheet_loadstore_wave
++@@ -743,10 +743,8 @@
+  		return -EINVAL;
+  
+  	err = request_firmware(&fw_entry, "broadsheet.wbf", dev);
+@@ -2136,7 +2120,7 @@
+  	if ((fw_entry->size < 8*1024) || (fw_entry->size > 64*1024)) {
+ --- a/drivers/video/fbdev/metronomefb.c
+ +++ b/drivers/video/fbdev/metronomefb.c
+-@@ -621,10 +621,8 @@ static int metronomefb_probe(struct plat
++@@ -621,10 +621,8 @@
+  		a) request the waveform file from userspace
+  		b) process waveform and decode into metromem */
+  	retval = request_firmware(&fw_entry, "metronome.wbf", &dev->dev);
+@@ -2150,7 +2134,7 @@
+  				par);
+ --- a/sound/drivers/vx/vx_hwdep.c
+ +++ b/sound/drivers/vx/vx_hwdep.c
+-@@ -58,10 +58,8 @@ int snd_vx_setup_firmware(struct vx_core
++@@ -58,10 +58,8 @@
+  		if (! fw_files[chip->type][i])
+  			continue;
+  		sprintf(path, "vx/%s", fw_files[chip->type][i]);
+@@ -2164,7 +2148,7 @@
+  			release_firmware(fw);
+ --- a/sound/isa/msnd/msnd_pinnacle.c
+ +++ b/sound/isa/msnd/msnd_pinnacle.c
+-@@ -376,15 +376,11 @@ static int upload_dsp_code(struct snd_ca
++@@ -376,15 +376,11 @@
+  	outb(HPBLKSEL_0, chip->io + HP_BLKS);
+  
+  	err = request_firmware(&init_fw, INITCODEFILE, card->dev);
+@@ -2184,7 +2168,7 @@
+  	if (snd_msnd_upload_host(chip, init_fw->data, init_fw->size) < 0) {
+ --- a/sound/isa/sscape.c
+ +++ b/sound/isa/sscape.c
+-@@ -520,10 +520,8 @@ static int sscape_upload_bootblock(struc
++@@ -520,10 +520,8 @@
+  	int ret;
+  
+  	ret = request_firmware(&init_fw, "scope.cod", card->dev);
+@@ -2196,7 +2180,7 @@
+  	ret = upload_dma_data(sscape, init_fw->data, init_fw->size);
+  
+  	release_firmware(init_fw);
+-@@ -560,11 +558,8 @@ static int sscape_upload_microcode(struc
++@@ -560,11 +558,8 @@
+  	scnprintf(name, sizeof(name), "sndscape.co%d", version);
+  
+  	err = request_firmware(&init_fw, name, card->dev);
+@@ -2211,7 +2195,7 @@
+  		snd_printk(KERN_INFO "sscape: MIDI firmware loaded %zu KBs\n",
+ --- a/sound/isa/wavefront/wavefront_synth.c
+ +++ b/sound/isa/wavefront/wavefront_synth.c
+-@@ -1970,10 +1970,8 @@ wavefront_download_firmware (snd_wavefro
++@@ -1970,10 +1970,8 @@
+  	const struct firmware *firmware;
+  
+  	err = request_firmware(&firmware, path, dev->card->dev);
+@@ -2225,7 +2209,7 @@
+  	buf = firmware->data;
+ --- a/sound/pci/asihpi/hpidspcd.c
+ +++ b/sound/pci/asihpi/hpidspcd.c
+-@@ -35,8 +35,6 @@ short hpi_dsp_code_open(u32 adapter, voi
++@@ -35,8 +35,6 @@
+  	err = request_firmware(&firmware, fw_name, &dev->dev);
+  
+  	if (err || !firmware) {
+@@ -2236,7 +2220,7 @@
+  	if (firmware->size < sizeof(header)) {
+ --- a/sound/pci/cs46xx/cs46xx_lib.c
+ +++ b/sound/pci/cs46xx/cs46xx_lib.c
+-@@ -3196,11 +3196,8 @@ int snd_cs46xx_start_dsp(struct snd_cs46
++@@ -3196,11 +3196,8 @@
+  #ifdef CONFIG_SND_CS46XX_NEW_DSP
+  	for (i = 0; i < CS46XX_DSP_MODULES; i++) {
+  		err = load_firmware(chip, &chip->modules[i], module_names[i]);
+@@ -2251,7 +2235,7 @@
+  			dev_err(chip->card->dev, "image download error [%s]\n",
+ --- a/sound/pci/echoaudio/echoaudio.c
+ +++ b/sound/pci/echoaudio/echoaudio.c
+-@@ -48,11 +48,8 @@ static int get_firmware(const struct fir
++@@ -48,11 +48,8 @@
+  		"firmware requested: %s\n", card_fw[fw_index].data);
+  	snprintf(name, sizeof(name), "ea/%s", card_fw[fw_index].data);
+  	err = request_firmware(fw_entry, name, &chip->pci->dev);
+@@ -2266,7 +2250,7 @@
+  	return err;
+ --- a/sound/pci/emu10k1/emu10k1_main.c
+ +++ b/sound/pci/emu10k1/emu10k1_main.c
+-@@ -864,10 +864,8 @@ static int snd_emu10k1_emu1010_init(stru
++@@ -881,10 +881,8 @@
+  	dev_info(emu->card->dev, "emu1010: EMU_HANA_ID = 0x%x\n", reg);
+  
+  	err = snd_emu1010_load_firmware(emu, 0, &emu->firmware);
+@@ -2280,7 +2264,7 @@
+  	snd_emu1010_fpga_read(emu, EMU_HANA_ID, &reg);
+ --- a/sound/pci/hda/hda_intel.c
+ +++ b/sound/pci/hda/hda_intel.c
+-@@ -2040,8 +2040,6 @@ static void azx_firmware_cb(const struct
++@@ -2042,8 +2042,6 @@
+  
+  	if (fw)
+  		chip->fw = fw;
+@@ -2291,7 +2275,7 @@
+  		azx_probe_continue(chip);
+ --- a/sound/pci/korg1212/korg1212.c
+ +++ b/sound/pci/korg1212/korg1212.c
+-@@ -2232,7 +2232,6 @@ static int snd_korg1212_create(struct sn
++@@ -2232,7 +2232,6 @@
+  
+  	err = request_firmware(&dsp_code, "korg/k1212.dsp", &pci->dev);
+  	if (err < 0) {
+@@ -2301,7 +2285,7 @@
+  
+ --- a/sound/pci/mixart/mixart_hwdep.c
+ +++ b/sound/pci/mixart/mixart_hwdep.c
+-@@ -566,11 +566,8 @@ int snd_mixart_setup_firmware(struct mix
++@@ -566,11 +566,8 @@
+  
+  	for (i = 0; i < 3; i++) {
+  		sprintf(path, "mixart/%s", fw_files[i]);
+@@ -2316,7 +2300,7 @@
+  		release_firmware(fw_entry);
+ --- a/sound/pci/pcxhr/pcxhr_hwdep.c
+ +++ b/sound/pci/pcxhr/pcxhr_hwdep.c
+-@@ -375,12 +375,8 @@ int pcxhr_setup_firmware(struct pcxhr_mg
++@@ -375,12 +375,8 @@
+  		if (!fw_files[fw_set][i])
+  			continue;
+  		sprintf(path, "pcxhr/%s", fw_files[fw_set][i]);
+@@ -2332,7 +2316,7 @@
+  		release_firmware(fw_entry);
+ --- a/sound/pci/riptide/riptide.c
+ +++ b/sound/pci/riptide/riptide.c
+-@@ -1222,11 +1222,8 @@ static int try_to_load_firmware(struct c
++@@ -1222,11 +1222,8 @@
+  	if (!chip->fw_entry) {
+  		err = request_firmware(&chip->fw_entry, "riptide.hex",
+  				       &chip->pci->dev);
+@@ -2347,7 +2331,7 @@
+  	if (err) {
+ --- a/sound/pci/rme9652/hdsp.c
+ +++ b/sound/pci/rme9652/hdsp.c
+-@@ -5171,11 +5171,8 @@ static int hdsp_request_fw_loader(struct
++@@ -5173,11 +5173,8 @@
+  		return -EINVAL;
+  	}
+  
+@@ -2362,7 +2346,7 @@
+  			"too short firmware size %d (expected %d)\n",
+ --- a/sound/soc/codecs/wm2000.c
+ +++ b/sound/soc/codecs/wm2000.c
+-@@ -891,10 +891,8 @@ static int wm2000_i2c_probe(struct i2c_c
++@@ -891,10 +891,8 @@
+  	}
+  
+  	ret = request_firmware(&fw, filename, &i2c->dev);
+@@ -2376,7 +2360,7 @@
+  	wm2000->anc_download_size = fw->size + 2;
+ --- a/sound/usb/6fire/firmware.c
+ +++ b/sound/usb/6fire/firmware.c
+-@@ -203,8 +203,6 @@ static int usb6fire_fw_ezusb_upload(
++@@ -203,8 +203,6 @@
+  	ret = request_firmware(&fw, fwname, &device->dev);
+  	if (ret < 0) {
+  		kfree(rec);
+@@ -2385,7 +2369,7 @@
+  		return ret;
+  	}
+  	ret = usb6fire_fw_ihex_init(fw, rec);
+-@@ -280,8 +278,6 @@ static int usb6fire_fw_fpga_upload(
++@@ -280,8 +278,6 @@
+  
+  	ret = request_firmware(&fw, fwname, &device->dev);
+  	if (ret < 0) {

--- a/fixes_debian/series
+++ b/fixes_debian/series
@@ -4,3 +4,4 @@ efi-lock-down-the-kernel-if-booted-in-secure-boot-mo.update.patch
 add-symsearch-rule-to-debian-makefiles.patch
 fixes-firmware-remove-redundant-log-messages-from-drivers.patch
 fix-security-perf-allow-further-restriction-of-perf_event_open.patch
+refresh-debian_firmware-remove-redundant-log-messages-from-drivers.patch

--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,5 @@
 pkg=linux
-version_orig=6.6.75
+version_orig=6.6.76
 version="$version_orig-0"
 
 (

--- a/prepare_source
+++ b/prepare_source
@@ -14,7 +14,8 @@ version="$version_orig-0"
 	git clone --depth 1 --branch "$debian_ref" "$debian_repo" linux
 	cd linux
 
-	apt-get install --no-install-recommends -y python3-debian # needed for genorig
+	apt-get install --no-install-recommends -y python3-debian gpgv # needed for genorig
+        apt-get remove --purge sqopv -y
 	debian/bin/genorig.py --override-version "$version_orig" "$kernel_repo"
 	git clean -fdx
 

--- a/upstream_patches/kbuild-switch-from-lz4c-to-lz4-for-compression.patch
+++ b/upstream_patches/kbuild-switch-from-lz4c-to-lz4-for-compression.patch
@@ -1,0 +1,73 @@
+From: Parth Pancholi <parth.pancholi@toradex.com>
+Date: Thu, 14 Nov 2024 15:56:44 +0100
+Subject: kbuild: switch from lz4c to lz4 for compression
+Origin: https://git.kernel.org/linus/e397a603e49cc7c7c113fad9f55a09637f290c34
+
+Replace lz4c with lz4 for kernel image compression.
+Although lz4 and lz4c are functionally similar, lz4c has been deprecated
+upstream since 2018. Since as early as Ubuntu 16.04 and Fedora 25, lz4
+and lz4c have been packaged together, making it safe to update the
+requirement from lz4c to lz4.
+
+Consequently, some distributions and build systems, such as OpenEmbedded,
+have fully transitioned to using lz4. OpenEmbedded core adopted this
+change in commit fe167e082cbd ("bitbake.conf: require lz4 instead of
+lz4c"), causing compatibility issues when building the mainline kernel
+in the latest OpenEmbedded environment, as seen in the errors below.
+
+This change also updates the LZ4 compression commands to make it backward
+compatible by replacing stdin and stdout with the '-' option, due to some
+unclear reason, the stdout keyword does not work for lz4 and '-' works for
+both. In addition, this modifies the legacy '-c1' with '-9' which is also
+compatible with both. This fixes the mainline kernel build failures with
+the latest master OpenEmbedded builds associated with the mentioned
+compatibility issues.
+
+LZ4     arch/arm/boot/compressed/piggy_data
+/bin/sh: 1: lz4c: not found
+...
+...
+ERROR: oe_runmake failed
+
+Link: https://github.com/lz4/lz4/pull/553
+Suggested-by: Francesco Dolcini <francesco.dolcini@toradex.com>
+Signed-off-by: Parth Pancholi <parth.pancholi@toradex.com>
+Signed-off-by: Masahiro Yamada <masahiroy@kernel.org>
+---
+ Makefile             | 2 +-
+ scripts/Makefile.lib | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 215d5fd95a28..f7f43c8997ae 100644
+--- a/Makefile
++++ b/Makefile
+@@ -533,7 +533,7 @@ KGZIP		= gzip
+ KBZIP2		= bzip2
+ KLZOP		= lzop
+ LZMA		= lzma
+-LZ4		= lz4c
++LZ4		= lz4
+ XZ		= xz
+ ZSTD		= zstd
+ 
+diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
+index 01040a767c1d..7395200538da 100644
+--- a/scripts/Makefile.lib
++++ b/scripts/Makefile.lib
+@@ -425,10 +425,10 @@ quiet_cmd_lzo_with_size = LZO     $@
+       cmd_lzo_with_size = { cat $(real-prereqs) | $(KLZOP) -9; $(size_append); } > $@
+ 
+ quiet_cmd_lz4 = LZ4     $@
+-      cmd_lz4 = cat $(real-prereqs) | $(LZ4) -l -c1 stdin stdout > $@
++      cmd_lz4 = cat $(real-prereqs) | $(LZ4) -l -9 - - > $@
+ 
+ quiet_cmd_lz4_with_size = LZ4     $@
+-      cmd_lz4_with_size = { cat $(real-prereqs) | $(LZ4) -l -c1 stdin stdout; \
++      cmd_lz4_with_size = { cat $(real-prereqs) | $(LZ4) -l -9 - -; \
+                   $(size_append); } > $@
+ 
+ # U-Boot mkimage
+-- 
+2.47.2
+

--- a/upstream_patches/series
+++ b/upstream_patches/series
@@ -87,3 +87,4 @@ fpga-ofs-dev-6.6-lts-patches/0086-.github-workflows-build-kernel-packages.patch
 fpga-ofs-dev-6.6-lts-patches/0087-.github-workflows-scan-kernel-with-Coverity.patch
 fpga-ofs-dev-6.6-lts-patches/0088-fpga-dfl-cxl-cache-depend-on-DRM.patch
 intel-dfl-fixes/001-fix-config-dependency-intel-s10hssi.patch
+kbuild-switch-from-lz4c-to-lz4-for-compression.patch


### PR DESCRIPTION
refreshes debian_firmware-remove-redundant-log-messages-from-drivers.patch so we can build 6.6.76 

