### PR TITLE
check that 6.12 kernel are marked as 'longterm' again

### DIFF
--- a/update-kernel.py
+++ b/update-kernel.py
@@ -15,7 +15,7 @@ def get_latest_kernel_version():
             r["version"]
             for r in releases
             if r["version"].startswith(current_lts)
-# not officially lts yet            and r["moniker"] == "longterm"
+            and r["moniker"] == "longterm"
             and r["iseol"] == False
         ]
         assert len(latest_current_lts) == 1


### PR DESCRIPTION
Reverting a temporary change for the time before 6.12 was lts officially.
