### PR TITLE
Ignore 'output' directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .build
+output


### PR DESCRIPTION
Working with [this approach](https://github.com/gardenlinux/package-build/blob/main/PATCHING.MD) will produce an output directory which should not be committed to the repo. As this might happen often in this repo, we should just ignore the directory to reduce noise.

<img width="341" alt="Screenshot 2025-04-11 at 10 15 44" src="https://github.com/user-attachments/assets/57e6ee60-1c89-4390-9150-0eed373ebbdb" />
