### PR TITLE
Update kernel to 6.12.42 and debian build to 6.12.41-1

### DIFF
--- a/config/defines.toml
+++ b/config/defines.toml
@@ -26,3 +26,7 @@ breaks = [
   'fwupdate (<< 12-7)',
   'wireless-regdb (<< 2019.06.03-1~)',
 ]
+
+[[debianrelease]]
+name_regex = 'gardenlinux'
+revision_regex = '\d+gl(\d+)?(~dev)?'

--- a/fixes_debian/fix-sh-boot-do-not-use-hyphen-in-exported-variable-name.patch
+++ b/fixes_debian/fix-sh-boot-do-not-use-hyphen-in-exported-variable-name.patch
@@ -1,0 +1,110 @@
+diff --color -Naur a/debian/patches/bugfix/sh/sh-boot-do-not-use-hyphen-in-exported-variable-name.patch b/debian/patches/bugfix/sh/sh-boot-do-not-use-hyphen-in-exported-variable-name.patch
+--- a/debian/patches/bugfix/sh/sh-boot-do-not-use-hyphen-in-exported-variable-name.patch	2025-08-12 05:28:04.000000000 +0200
++++ b/debian/patches/bugfix/sh/sh-boot-do-not-use-hyphen-in-exported-variable-name.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,95 +0,0 @@
+-From: Ben Hutchings <ben@decadent.org.uk>
+-Date: Mon, 07 Feb 2022 00:00:26 +0100
+-Subject: sh: Do not use hyphen in exported variable names
+-
+-arch/sh/Makefile defines and exports ld-bfd to be used by
+-arch/sh/boot/Makefile and arch/sh/boot/compressed/Makefile.  However
+-some shells, including dash, will not pass through environment
+-variables whose name includes a hyphen.  Usually GNU make does not use
+-a shell to recurse, but if e.g. $(srctree) contains '~' it will use a
+-shell here.
+-
+-Rename the variable to ld_bfd.
+-
+-(Another instance of this problem was fixed upstream by commit
+-82977af93a0d "sh: rename suffix-y to suffix_y".)
+-
+-References: https://buildd.debian.org/status/fetch.php?pkg=linux&arch=sh4&ver=4.13%7Erc5-1%7Eexp1&stamp=1502943967&raw=0
+-Fixes: ef9b542fce00 ("sh: bzip2/lzma uImage support.")
+-Signed-off-by: Ben Hutchings <ben@decadent.org.uk>
+----
+- arch/sh/Makefile                 | 10 +++++-----
+- arch/sh/boot/compressed/Makefile |  4 ++--
+- arch/sh/boot/romimage/Makefile   |  4 ++--
+- 3 files changed, 9 insertions(+), 9 deletions(-)
+-
+-Index: linux/arch/sh/Makefile
+-===================================================================
+---- linux.orig/arch/sh/Makefile
+-+++ linux/arch/sh/Makefile
+-@@ -102,16 +102,16 @@ UTS_MACHINE		:= sh
+- LDFLAGS_vmlinux		+= -e _stext
+- 
+- ifdef CONFIG_CPU_LITTLE_ENDIAN
+--ld-bfd			:= elf32-sh-linux
+--LDFLAGS_vmlinux		+= --defsym jiffies=jiffies_64 --oformat $(ld-bfd)
+-+ld_bfd			:= elf32-sh-linux
+-+LDFLAGS_vmlinux		+= --defsym jiffies=jiffies_64 --oformat $(ld_bfd)
+- KBUILD_LDFLAGS		+= -EL
+- else
+--ld-bfd			:= elf32-shbig-linux
+--LDFLAGS_vmlinux		+= --defsym jiffies=jiffies_64+4 --oformat $(ld-bfd)
+-+ld_bfd			:= elf32-shbig-linux
+-+LDFLAGS_vmlinux		+= --defsym jiffies=jiffies_64+4 --oformat $(ld_bfd)
+- KBUILD_LDFLAGS		+= -EB
+- endif
+- 
+--export ld-bfd
+-+export ld_bfd
+- 
+- # Mach groups
+- machdir-$(CONFIG_SOLUTION_ENGINE)		+= mach-se
+-Index: linux/arch/sh/boot/compressed/Makefile
+-===================================================================
+---- linux.orig/arch/sh/boot/compressed/Makefile
+-+++ linux/arch/sh/boot/compressed/Makefile
+-@@ -36,7 +36,7 @@ endif
+- 
+- ccflags-remove-$(CONFIG_MCOUNT) += -pg
+- 
+--LDFLAGS_vmlinux := --oformat $(ld-bfd) -Ttext $(IMAGE_OFFSET) -e startup \
+-+LDFLAGS_vmlinux := --oformat $(ld_bfd) -Ttext $(IMAGE_OFFSET) -e startup \
+- 		   -T $(obj)/../../kernel/vmlinux.lds
+- 
+- KBUILD_CFLAGS += -DDISABLE_BRANCH_PROFILING
+-@@ -60,7 +60,7 @@ $(obj)/vmlinux.bin.lzo: $(obj)/vmlinux.b
+- 
+- OBJCOPYFLAGS += -R .empty_zero_page
+- 
+--LDFLAGS_piggy.o := -r --format binary --oformat $(ld-bfd) -T
+-+LDFLAGS_piggy.o := -r --format binary --oformat $(ld_bfd) -T
+- 
+- $(obj)/piggy.o: $(obj)/vmlinux.scr $(obj)/vmlinux.bin.$(suffix_y) FORCE
+- 	$(call if_changed,ld)
+-Index: linux/arch/sh/boot/romimage/Makefile
+-===================================================================
+---- linux.orig/arch/sh/boot/romimage/Makefile
+-+++ linux/arch/sh/boot/romimage/Makefile
+-@@ -13,7 +13,7 @@ mmcif-obj-$(CONFIG_CPU_SUBTYPE_SH7724)	:
+- load-$(CONFIG_ROMIMAGE_MMCIF)		:= $(mmcif-load-y)
+- obj-$(CONFIG_ROMIMAGE_MMCIF)		:= $(mmcif-obj-y)
+- 
+--LDFLAGS_vmlinux := --oformat $(ld-bfd) -Ttext $(load-y) -e romstart \
+-+LDFLAGS_vmlinux := --oformat $(ld_bfd) -Ttext $(load-y) -e romstart \
+- 		   -T $(obj)/../../kernel/vmlinux.lds
+- 
+- $(obj)/vmlinux: $(obj)/head.o $(obj-y) $(obj)/piggy.o FORCE
+-@@ -24,7 +24,7 @@ OBJCOPYFLAGS += -j .empty_zero_page
+- $(obj)/zeropage.bin: vmlinux FORCE
+- 	$(call if_changed,objcopy)
+- 
+--LDFLAGS_piggy.o := -r --format binary --oformat $(ld-bfd) -T
+-+LDFLAGS_piggy.o := -r --format binary --oformat $(ld_bfd) -T
+- 
+- $(obj)/piggy.o: $(obj)/vmlinux.scr $(obj)/zeropage.bin arch/sh/boot/zImage FORCE
+- 	$(call if_changed,ld)
+diff --color -Naur a/debian/patches/series b/debian/patches/series
+--- a/debian/patches/series	2025-08-12 05:28:04.000000000 +0200
++++ b/debian/patches/series	2025-08-18 14:12:54.829732249 +0200
+@@ -60,7 +60,6 @@
+ # Arch bug fixes
+ bugfix/arm/arm-dts-kirkwood-fix-sata-pinmux-ing-for-ts419.patch
+ bugfix/x86/perf-tools-fix-unwind-build-on-i386.patch
+-bugfix/sh/sh-boot-do-not-use-hyphen-in-exported-variable-name.patch
+ bugfix/arm/arm-mm-export-__sync_icache_dcache-for-xen-privcmd.patch
+ bugfix/powerpc/powerpc-boot-fix-missing-crc32poly.h-when-building-with-kernel_xz.patch
+ bugfix/arm64/arm64-acpi-Add-fixup-for-HPE-m400-quirks.patch

--- a/fixes_debian/series
+++ b/fixes_debian/series
@@ -1,0 +1,1 @@
+fix-sh-boot-do-not-use-hyphen-in-exported-variable-name.patch

--- a/prepare_source
+++ b/prepare_source
@@ -1,10 +1,10 @@
 pkg=linux
-version_orig=6.12.41
+version_orig=6.12.42
 version="$version_orig-2"
 
 (
 	debian_repo=https://salsa.debian.org/kernel-team/linux.git
-	debian_ref="debian/6.12.29-1"
+	debian_ref="debian/6.12.41-1"
 
 	tmp_dir="$(mktemp -d)"
 	trap 'cd / && rm -rf "$tmp_dir"' EXIT


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update to latest 6.12 kernel
- Delete a patch from debian that was included in the upstream kernel (this must probably be reverted once debian updates the repo)
- Configure a `debianrelease` for Garden Linux as this is required in [this new commit](https://salsa.debian.org/kernel-team/linux/-/commit/76d1e2c5fab2a2a4bf7699091ff77d7cf11d40ef) in debian's kernel config

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/3304
