### PR TITLE
Update version regex to match nightly, dev and bp-rel versions

### DIFF
--- a/config/defines.toml
+++ b/config/defines.toml
@@ -29,4 +29,4 @@ breaks = [
 
 [[debianrelease]]
 name_regex = 'gardenlinux'
-revision_regex = '\d+gl(\d+)?(~dev)?'
+revision_regex = '\d+gl(\d+)?(~bp\d+)?(~dev)?'


### PR DESCRIPTION
This change is required to be able to build backport versions of the kernel. Debian has a regex-based version number validation and our builds in rel-1877 failed first because the version number did not match. This regex should match all cases we need.