### PR TITLE
docs: remove "AI-generated phrasing"

### DIFF
--- a/docs/explanation/kernel.md
+++ b/docs/explanation/kernel.md
@@ -54,12 +54,12 @@ Debian scans licenses and patches out everything
 that violates the claim to stay 100% free. Since Garden Linux shares this
 approach, we benefit from Debian patches.
 
-Additionally, Debian provides a good kernel configuration,
+Debian also provides a good kernel configuration,
 which is used by Garden Linux as a base for configuration.
 We extend this kernel configuration to our specific requirements during the
 kernel integration process.
 
-Additionally, Debian kernel [patches](https://salsa.debian.org/kernel-team/linux/-/tree/master/debian/patches) are applied in most cases.
+Debian kernel [patches](https://salsa.debian.org/kernel-team/linux/-/tree/master/debian/patches) are applied in most cases.
 
 ## Further reading
 

--- a/docs/explanation/kernel.md
+++ b/docs/explanation/kernel.md
@@ -59,7 +59,7 @@ which is used by Garden Linux as a base for configuration.
 We extend this kernel configuration to our specific requirements during the
 kernel integration process.
 
-Furthermore, Debian kernel [patches](https://salsa.debian.org/kernel-team/linux/-/tree/master/debian/patches) are applied in most cases.
+Additionally, Debian kernel [patches](https://salsa.debian.org/kernel-team/linux/-/tree/master/debian/patches) are applied in most cases.
 
 ## Further reading
 

--- a/docs/how-to/kernel-builds.md
+++ b/docs/how-to/kernel-builds.md
@@ -103,7 +103,7 @@ A scheduled workflow scans a list of configured branches [see](https://github.co
 The automation creates a PR if a new patch level is available.
 
 :::warning
-Note that build failures in this PR will not be visible in the way you are used to it.
+Build failures in this PR will not be visible in the way you are used to it.
 This is due to limitations on GitHub.
 Always check the PR-related workflow manually before merge as it might well be that an upgrade of the kernel breaks the build.
 [See this issue for more information if you are interested](https://github.com/gardenlinux/package-linux/issues/47).


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes "AI-generated phrasing". Definitions what qualifies at such phrasing [as documented](https://github.com/gardenlinux/docs-ng/blob/dda94b0dd8911e5688dbc81f73b42803ccd1944a/docs/contributing/documentation/writing_good_docs.md#ai-generated-phrasing-to-avoid).
The removal of the phrases was done via the [documentation-humanize workflow](https://github.com/gardenlinux/agent-skills/blob/b4681613ef763884f4e80d4ffb29649d160121a5/workflows/documentation-humanize.md) and [skill](https://github.com/gardenlinux/agent-skills/blob/b4681613ef763884f4e80d4ffb29649d160121a5/skills/documentation-humanize/SKILL.md).