### PR TITLE
feat: remove migration frontmatter as migration is done

### DIFF
--- a/docs/explanation/kernel.md
+++ b/docs/explanation/kernel.md
@@ -6,11 +6,6 @@ related_topics:
   - /explanation/kernel.md
   - /how-to/kernel-builds.md
   - /reference/kernel-flavors.md
-migration_status: "done"
-migration_source: "00_introduction/kernel.md"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4629"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-linux
 github_source_path: docs/explanation/kernel.md

--- a/docs/how-to/kernel-builds.md
+++ b/docs/how-to/kernel-builds.md
@@ -5,10 +5,6 @@ related_topics:
   - /explanation/kernel.md
   - /how-to/kernel-builds.md
   - /reference/kernel-flavors.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4629"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-linux
 github_source_path: docs/how-to/kernel-builds.md

--- a/docs/reference/kernel-flavors.md
+++ b/docs/reference/kernel-flavors.md
@@ -5,10 +5,6 @@ related_topics:
   - /explanation/kernel.md
   - /how-to/kernel-builds.md
   - /reference/kernel-flavors.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4629"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-linux
 github_source_path: docs/reference/kernel-flavors.md


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/gardenlinux/gardenlinux/issues/4332 we used migration markers in the frontmatter to track the migration status. These can now be removed as the documentation system is live.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/5048
