### PR TITLE
Bump to 41 Kernel for 2150.8.0

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,5 @@
 pkg=linux
-version_orig=6.18.38
+version_orig=6.18.41
 version="$version_orig-1"
 
 (
@@ -28,4 +28,4 @@ cp -r config "$dir/src/debian/"
 
 apply_patches fixes_debian
 import_upstream_patches
-version_suffix=gl1~bp2150
+version_suffix=gl0~bp2150


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps kernel to 6.18.41gl0~2150 for 2150.8.0
